### PR TITLE
Prøver lige at fixe de lint errors igen

### DIFF
--- a/frontend/src/pages/EventDetailPage.tsx
+++ b/frontend/src/pages/EventDetailPage.tsx
@@ -21,6 +21,7 @@ import {
   Typography,
   Textarea,
   Alert,
+  Anchor,
 } from "@mantine/core"
 import { useDisclosure } from "@mantine/hooks"
 import { notifications } from "@mantine/notifications"
@@ -37,6 +38,7 @@ import {
   IconAlertCircle,
   IconMessage,
   IconCalendarPlus,
+  IconExternalLink,
 } from "@tabler/icons-react"
 import dayjs from "dayjs"
 
@@ -764,8 +766,8 @@ interface UpdatePostMutationProps {
 
 function DiscussionSection({
   threadId,
-  subgroupSlug: _subgroupSlug,
-  threadSlug: _threadSlug,
+  subgroupSlug,
+  threadSlug,
 }: DiscussionSectionProps) {
   const queryClient = useQueryClient()
   const location = useLocation()


### PR DESCRIPTION
## Summary

The original commit (`a22c586`) correctly fixed a tsgo false positive by converting a short-circuit (`&&`) JSX expression to an explicit ternary. However, the follow-up "fix lint" commit (`131967c`) broke it: oxlint still reported `subgroupSlug`, `threadSlug`, `Anchor`, and `IconExternalLink` as unused — likely because it doesn't track variable usage inside ternary branches correctly. That commit blindly silenced the warnings by removing the imports and prefixing the destructured props with `_`, which meant the forum link in the discussion section no longer compiled.

This PR restores the imports and variable names so the "Se i forum" link works again.

## Changes
- Restore `Anchor` and `IconExternalLink` imports
- Remove `_` prefix from `subgroupSlug` / `threadSlug` destructuring

## Test plan
- [ ] Open an event with a linked forum thread and verify the "Se i forum" link renders and navigates correctly
- [ ] `npm run typecheck` and `npm run lint` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)