### PR TITLE
Update deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -50,7 +50,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Building new images (old containers keep serving)..."
-docker compose build
+docker compose build --pull
 
 echo "Running startup tasks with new image (old server still serving)..."
 docker compose run --rm -T --entrypoint sh backend -c "


### PR DESCRIPTION
In deploy.sh, change line 53 from:

  docker compose build

  to:

  docker compose build --pull

  The --pull flag makes Docker always check for an updated version of the python:3.11-slim base image when building. Without it, Docker
   reuses a cached base image layer that might be months old — and older python:3.11-slim images can include a SQLite compiled without
  the JSON1 extension. That causes Django's fields.E180 system check error ("SQLite does not support JSONFields") on any model using
  models.JSONField. All four affected fields (users.User.default_cooking_days, food.FoodTeamCycle.cooking_dates,
  food.FoodTeamWish.available_dates, bookings.RecurringBooking.days_of_week) are fine — it's purely the base image SQLite that needs to
   be fresh.