### PR TITLE
Forum: folder visibility, permissions, deletion, and duplicate-name guard

### DIFF
--- a/backend/apps/forum/serializers.py
+++ b/backend/apps/forum/serializers.py
@@ -985,10 +985,21 @@ class FolderSerializer(serializers.ModelSerializer):
         ]
 
     def get_file_count(self, obj: Folder) -> int:
-        return obj.files.count()
+        from .services import visible_files_q
+
+        request = self.context.get("request")
+        user = request.user if request else None
+        return obj.files.filter(visible_files_q(user)).count()
 
     def get_subfolder_count(self, obj: Folder) -> int:
-        return obj.children.count()
+        from .services import visible_folder_ids
+
+        visible_ids = self.context.get("visible_folder_ids")
+        if visible_ids is None:
+            request = self.context.get("request")
+            user = request.user if request else None
+            visible_ids = visible_folder_ids(user, obj.subgroup) if obj.subgroup_id else set()
+        return obj.children.filter(id__in=visible_ids).count()
 
 
 class FolderCreateSerializer(serializers.ModelSerializer):
@@ -998,6 +1009,20 @@ class FolderCreateSerializer(serializers.ModelSerializer):
         model = Folder
         fields = ["name", "slug", "parent"]
         read_only_fields = ["slug"]
+
+    def validate(self, attrs: dict) -> dict:
+        # The model has UniqueConstraint(subgroup, parent, name), but in SQLite
+        # (and PostgreSQL by default) NULL parent_ids are treated as distinct,
+        # so root-level duplicates slip through. Validate here so both cases
+        # return a clean field error rather than an IntegrityError.
+        name = attrs.get("name")
+        parent = attrs.get("parent")
+        subgroup = self.context["subgroup"]
+        if Folder.objects.filter(subgroup=subgroup, parent=parent, name=name).exists():
+            raise serializers.ValidationError(
+                {"name": "Der findes allerede en mappe med dette navn her."}
+            )
+        return attrs
 
     def create(self, validated_data: dict) -> Folder:
         validated_data["subgroup"] = self.context["subgroup"]

--- a/backend/apps/forum/services.py
+++ b/backend/apps/forum/services.py
@@ -12,6 +12,7 @@ from django.db.models import Q
 
 from .models import (
     File,
+    Folder,
     Subgroup,
     SubgroupMembership,
     SubgroupSubscription,
@@ -117,3 +118,59 @@ def filter_visible_threads(qs: QuerySet[Thread], user: User) -> QuerySet[Thread]
 
 def filter_visible_files(qs: QuerySet[File], user: User) -> QuerySet[File]:
     return qs.filter(visible_files_q(user))
+
+
+def folder_subtree_ids(folder: Folder) -> set[int]:
+    """Return the folder's own ID plus all descendant folder IDs."""
+    ids: set[int] = {folder.id}
+    frontier = [folder.id]
+    while frontier:
+        children = list(Folder.objects.filter(parent_id__in=frontier).values_list("id", flat=True))
+        new = [c for c in children if c not in ids]
+        ids.update(new)
+        frontier = new
+    return ids
+
+
+def visible_folder_ids(user: User, subgroup: Subgroup) -> set[int]:
+    """Return folder IDs in `subgroup` that `user` is allowed to see.
+
+    Users with the right to see the full directory structure (formal members,
+    or any authenticated user when the subgroup does not enforce privacy) see
+    every folder, including empty ones — otherwise a freshly created folder
+    would be invisible to its creator until a file is uploaded to it.
+
+    Otherwise, a folder is shown only if it (or any descendant) contains a
+    file the user can view, so the directory structure itself does not leak
+    the existence of private content.
+    """
+    sees_all = (
+        user
+        and user.is_authenticated
+        and (
+            not subgroup.allows_members
+            or SubgroupMembership.objects.filter(user=user, subgroup=subgroup).exists()
+        )
+    )
+    if sees_all:
+        return set(Folder.objects.filter(subgroup=subgroup).values_list("id", flat=True))
+
+    file_folder_ids = set(
+        File.objects.filter(visible_files_q(user), subgroup=subgroup)
+        .exclude(folder__isnull=True)
+        .values_list("folder_id", flat=True)
+        .distinct()
+    )
+
+    if not file_folder_ids:
+        return set()
+
+    parent_map = dict(Folder.objects.filter(subgroup=subgroup).values_list("id", "parent_id"))
+
+    visible: set[int] = set()
+    for fid in file_folder_ids:
+        cur: int | None = fid
+        while cur is not None and cur not in visible:
+            visible.add(cur)
+            cur = parent_map.get(cur)
+    return visible

--- a/backend/apps/forum/tests.py
+++ b/backend/apps/forum/tests.py
@@ -505,14 +505,28 @@ class TestPostViews:
 class TestFolderViews:
     """Tests for folder views."""
 
-    def test_list_folders(self, authenticated_client, subgroup, folder):
+    def test_list_folders(self, authenticated_client, user, subgroup, folder):
         """Test listing folders in a subgroup."""
+        File.objects.create(
+            subgroup=subgroup,
+            folder=folder,
+            uploaded_by=user,
+            file=SimpleUploadedFile("public.txt", b"x"),
+            name="public.txt",
+        )
         response = authenticated_client.get(f"/api/forum/subgroups/{subgroup.slug}/folders/")
         assert response.status_code == 200
         assert len(get_results(response.data)) == 1
 
-    def test_list_subfolders(self, authenticated_client, subgroup, folder, subfolder):
+    def test_list_subfolders(self, authenticated_client, user, subgroup, folder, subfolder):
         """Test listing subfolders with parent parameter."""
+        File.objects.create(
+            subgroup=subgroup,
+            folder=subfolder,
+            uploaded_by=user,
+            file=SimpleUploadedFile("public.txt", b"x"),
+            name="public.txt",
+        )
         response = authenticated_client.get(
             f"/api/forum/subgroups/{subgroup.slug}/folders/?parent={folder.id}"
         )
@@ -539,6 +553,159 @@ class TestFolderViews:
         assert response.status_code == 201
         new_folder = Folder.objects.get(name="New Subfolder")
         assert new_folder.parent == folder
+
+    def test_non_member_cannot_create_folder_in_members_only_subgroup(
+        self, second_authenticated_client, db
+    ):
+        """Non-members may upload files but not create folders in a private subgroup."""
+        members_only = Subgroup.objects.create(
+            name="Privat udvalg",
+            description="x",
+            slug="privat-udvalg",
+            is_committee=True,
+            allows_members=True,
+        )
+        response = second_authenticated_client.post(
+            f"/api/forum/subgroups/{members_only.slug}/folders/",
+            {"name": "Should Not Exist"},
+        )
+        assert response.status_code == 403
+        assert not Folder.objects.filter(name="Should Not Exist").exists()
+
+    def test_non_member_can_create_folder_in_open_subgroup(
+        self, second_authenticated_client, subgroup
+    ):
+        """Open subgroups (allows_members=False) have no privacy boundary, so
+        any authenticated user can create folders."""
+        response = second_authenticated_client.post(
+            f"/api/forum/subgroups/{subgroup.slug}/folders/",
+            {"name": "Open Folder"},
+        )
+        assert response.status_code == 201
+        assert Folder.objects.filter(name="Open Folder").exists()
+
+    def test_member_can_create_folder_in_members_only_subgroup(
+        self, member_client, member_subgroup
+    ):
+        response = member_client.post(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folders/",
+            {"name": "Member Folder"},
+        )
+        assert response.status_code == 201
+        assert Folder.objects.filter(name="Member Folder").exists()
+
+    def test_delete_folder_cascades_files_and_subfolders(
+        self, authenticated_client, user, subgroup
+    ):
+        """Deleting a folder removes its files and all descendant subfolders."""
+        parent = Folder.objects.create(subgroup=subgroup, name="Parent")
+        child = Folder.objects.create(subgroup=subgroup, name="Child", parent=parent)
+        f1 = File.objects.create(
+            subgroup=subgroup,
+            folder=parent,
+            uploaded_by=user,
+            file=SimpleUploadedFile("a.txt", b"a"),
+            name="a.txt",
+        )
+        f2 = File.objects.create(
+            subgroup=subgroup,
+            folder=child,
+            uploaded_by=user,
+            file=SimpleUploadedFile("b.txt", b"b"),
+            name="b.txt",
+        )
+
+        response = authenticated_client.delete(f"/api/forum/folders/{parent.id}/")
+        assert response.status_code == 204
+        assert not Folder.objects.filter(id=parent.id).exists()
+        assert not Folder.objects.filter(id=child.id).exists()
+        assert not File.objects.filter(id__in=[f1.id, f2.id]).exists()
+
+    def test_non_member_cannot_delete_folder_in_members_only_subgroup(
+        self, second_authenticated_client, user, member_subgroup
+    ):
+        folder = Folder.objects.create(subgroup=member_subgroup, name="Privat mappe")
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=folder,
+            uploaded_by=user,
+            file=SimpleUploadedFile("public.txt", b"x"),
+            name="public.txt",
+        )
+        response = second_authenticated_client.delete(f"/api/forum/folders/{folder.id}/")
+        assert response.status_code == 403
+        assert Folder.objects.filter(id=folder.id).exists()
+
+    def test_member_can_delete_folder_in_members_only_subgroup(
+        self, member_client, member_subgroup
+    ):
+        folder = Folder.objects.create(subgroup=member_subgroup, name="Mappe")
+        response = member_client.delete(f"/api/forum/folders/{folder.id}/")
+        assert response.status_code == 204
+        assert not Folder.objects.filter(id=folder.id).exists()
+
+    def test_delete_preview_returns_recursive_counts(self, authenticated_client, user, subgroup):
+        parent = Folder.objects.create(subgroup=subgroup, name="Parent")
+        child = Folder.objects.create(subgroup=subgroup, name="Child", parent=parent)
+        Folder.objects.create(subgroup=subgroup, name="Grandchild", parent=child)
+        File.objects.create(
+            subgroup=subgroup,
+            folder=parent,
+            uploaded_by=user,
+            file=SimpleUploadedFile("a.txt", b"a"),
+            name="a.txt",
+        )
+        File.objects.create(
+            subgroup=subgroup,
+            folder=child,
+            uploaded_by=user,
+            file=SimpleUploadedFile("b.txt", b"b"),
+            name="b.txt",
+        )
+        response = authenticated_client.get(f"/api/forum/folders/{parent.id}/delete-preview/")
+        assert response.status_code == 200
+        assert response.data == {"file_count": 2, "subfolder_count": 2}
+
+    def test_delete_preview_forbidden_for_non_member_in_members_only_subgroup(
+        self, second_authenticated_client, member_subgroup
+    ):
+        folder = Folder.objects.create(subgroup=member_subgroup, name="Privat")
+        response = second_authenticated_client.get(
+            f"/api/forum/folders/{folder.id}/delete-preview/"
+        )
+        assert response.status_code == 403
+
+    def test_cannot_create_duplicate_root_folder(self, authenticated_client, subgroup, folder):
+        """Two root-level folders cannot share a name (NULL parent edge case)."""
+        response = authenticated_client.post(
+            f"/api/forum/subgroups/{subgroup.slug}/folders/",
+            {"name": folder.name},
+        )
+        assert response.status_code == 400
+        assert "name" in response.data
+
+    def test_cannot_create_duplicate_subfolder(
+        self, authenticated_client, subgroup, folder, subfolder
+    ):
+        """Two subfolders under the same parent cannot share a name."""
+        response = authenticated_client.post(
+            f"/api/forum/subgroups/{subgroup.slug}/folders/",
+            {"name": subfolder.name, "parent": folder.id},
+        )
+        assert response.status_code == 400
+        assert "name" in response.data
+
+    def test_can_create_same_name_in_different_parents(
+        self, authenticated_client, subgroup, folder
+    ):
+        """Same name is allowed when parents differ — uniqueness is per-parent."""
+        other_parent = Folder.objects.create(subgroup=subgroup, name="Other")
+        Folder.objects.create(subgroup=subgroup, name="Shared", parent=folder)
+        response = authenticated_client.post(
+            f"/api/forum/subgroups/{subgroup.slug}/folders/",
+            {"name": "Shared", "parent": other_parent.id},
+        )
+        assert response.status_code == 201
 
 
 class TestFileViews:
@@ -1667,6 +1834,192 @@ class TestPrivateFileVisibility:
         assert response.status_code == 200
         ids = [f["id"] for f in get_results(response.data)]
         assert private_file.id in ids
+
+
+class TestPrivateFolderVisibility:
+    """Folders containing only private files must be hidden from non-members.
+
+    A folder is shown to a non-member only when it (or any descendant) holds at
+    least one file the user can see — otherwise the directory structure leaks
+    the existence of private content.
+    """
+
+    @pytest.fixture
+    def private_folder(self, db, user, member_subgroup):
+        folder = Folder.objects.create(subgroup=member_subgroup, name="Privat mappe")
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=folder,
+            uploaded_by=user,
+            name="hemmeligt.pdf",
+            file=SimpleUploadedFile("hemmeligt.pdf", b"secret"),
+            members_only=True,
+        )
+        return folder
+
+    @pytest.fixture
+    def public_folder(self, db, user, member_subgroup):
+        folder = Folder.objects.create(subgroup=member_subgroup, name="Offentlig mappe")
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=folder,
+            uploaded_by=user,
+            name="aaben.pdf",
+            file=SimpleUploadedFile("aaben.pdf", b"public"),
+            members_only=False,
+        )
+        return folder
+
+    def test_non_member_does_not_see_private_folder_in_list(
+        self, second_authenticated_client, member_subgroup, private_folder
+    ):
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folders/"
+        )
+        assert response.status_code == 200
+        ids = [f["id"] for f in get_results(response.data)]
+        assert private_folder.id not in ids
+
+    def test_non_member_does_not_see_empty_folder_in_list(
+        self, second_authenticated_client, db, member_subgroup
+    ):
+        empty = Folder.objects.create(subgroup=member_subgroup, name="Tom mappe")
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folders/"
+        )
+        assert response.status_code == 200
+        ids = [f["id"] for f in get_results(response.data)]
+        assert empty.id not in ids
+
+    def test_non_member_sees_folder_with_public_file(
+        self, second_authenticated_client, member_subgroup, public_folder
+    ):
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folders/"
+        )
+        assert response.status_code == 200
+        ids = [f["id"] for f in get_results(response.data)]
+        assert public_folder.id in ids
+
+    def test_non_member_sees_ancestor_when_descendant_has_public_file(
+        self, second_authenticated_client, db, user, member_subgroup
+    ):
+        parent = Folder.objects.create(subgroup=member_subgroup, name="Forælder")
+        child = Folder.objects.create(subgroup=member_subgroup, name="Barn", parent=parent)
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=child,
+            uploaded_by=user,
+            name="aaben.pdf",
+            file=SimpleUploadedFile("aaben.pdf", b"public"),
+            members_only=False,
+        )
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folders/"
+        )
+        ids = [f["id"] for f in get_results(response.data)]
+        assert parent.id in ids
+
+    def test_member_sees_private_folder_in_list(
+        self, member_client, member_subgroup, private_folder
+    ):
+        response = member_client.get(f"/api/forum/subgroups/{member_subgroup.slug}/folders/")
+        assert response.status_code == 200
+        ids = [f["id"] for f in get_results(response.data)]
+        assert private_folder.id in ids
+
+    def test_member_sees_empty_folder_in_list(self, member_client, db, member_subgroup):
+        """A freshly created (empty) folder must remain visible to its members,
+        otherwise the create-folder UX appears broken."""
+        empty = Folder.objects.create(subgroup=member_subgroup, name="Tom mappe")
+        response = member_client.get(f"/api/forum/subgroups/{member_subgroup.slug}/folders/")
+        assert response.status_code == 200
+        ids = [f["id"] for f in get_results(response.data)]
+        assert empty.id in ids
+
+    def test_empty_folder_visible_in_open_subgroup(self, second_authenticated_client, db, subgroup):
+        """Open subgroups (allows_members=False) have no privacy, so empty
+        folders must be visible to everyone — otherwise creating a folder in
+        an open subgroup leaves it invisible to its creator."""
+        empty = Folder.objects.create(subgroup=subgroup, name="Tom mappe")
+        response = second_authenticated_client.get(f"/api/forum/subgroups/{subgroup.slug}/folders/")
+        assert response.status_code == 200
+        ids = [f["id"] for f in get_results(response.data)]
+        assert empty.id in ids
+
+    def test_non_member_cannot_retrieve_private_folder_by_slug(
+        self, second_authenticated_client, member_subgroup, private_folder
+    ):
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folder/{private_folder.slug}/"
+        )
+        assert response.status_code == 404
+
+    def test_non_member_cannot_retrieve_private_folder_by_id(
+        self, second_authenticated_client, member_subgroup, private_folder
+    ):
+        response = second_authenticated_client.get(f"/api/forum/folders/{private_folder.id}/")
+        assert response.status_code == 404
+
+    def test_file_count_excludes_private_files_for_non_member(
+        self, second_authenticated_client, db, user, member_subgroup
+    ):
+        folder = Folder.objects.create(subgroup=member_subgroup, name="Blandet")
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=folder,
+            uploaded_by=user,
+            name="aaben.pdf",
+            file=SimpleUploadedFile("aaben.pdf", b"public"),
+            members_only=False,
+        )
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=folder,
+            uploaded_by=user,
+            name="hemmeligt.pdf",
+            file=SimpleUploadedFile("hemmeligt.pdf", b"secret"),
+            members_only=True,
+        )
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folders/"
+        )
+        results = get_results(response.data)
+        row = next(r for r in results if r["id"] == folder.id)
+        assert row["file_count"] == 1
+
+    def test_subfolder_count_excludes_private_subfolders_for_non_member(
+        self, second_authenticated_client, db, user, member_subgroup
+    ):
+        parent = Folder.objects.create(subgroup=member_subgroup, name="Forælder")
+        public_child = Folder.objects.create(
+            subgroup=member_subgroup, name="Offentlig", parent=parent
+        )
+        private_child = Folder.objects.create(
+            subgroup=member_subgroup, name="Privat", parent=parent
+        )
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=public_child,
+            uploaded_by=user,
+            name="aaben.pdf",
+            file=SimpleUploadedFile("aaben.pdf", b"public"),
+            members_only=False,
+        )
+        File.objects.create(
+            subgroup=member_subgroup,
+            folder=private_child,
+            uploaded_by=user,
+            name="hemmeligt.pdf",
+            file=SimpleUploadedFile("hemmeligt.pdf", b"secret"),
+            members_only=True,
+        )
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/folders/"
+        )
+        results = get_results(response.data)
+        row = next(r for r in results if r["id"] == parent.id)
+        assert row["subfolder_count"] == 1
 
 
 class TestMembershipNotifications:

--- a/backend/apps/forum/urls.py
+++ b/backend/apps/forum/urls.py
@@ -9,6 +9,7 @@ from .views import (
     FileListCreateView,
     FileMoveView,
     FolderBySlugView,
+    FolderDeletePreviewView,
     FolderDetailView,
     FolderDownloadView,
     FolderListCreateView,
@@ -103,6 +104,11 @@ urlpatterns = [
     # Folders
     path("subgroups/<slug:slug>/folders/", FolderListCreateView.as_view(), name="folder-list"),
     path("folders/<int:pk>/", FolderDetailView.as_view(), name="folder-detail"),
+    path(
+        "folders/<int:pk>/delete-preview/",
+        FolderDeletePreviewView.as_view(),
+        name="folder-delete-preview",
+    ),
     path("folders/<int:pk>/download/", FolderDownloadView.as_view(), name="folder-download"),
     path(
         "subgroups/<slug:slug>/folder/<str:folder_slug>/",

--- a/backend/apps/forum/views.py
+++ b/backend/apps/forum/views.py
@@ -7,7 +7,7 @@ import zipfile
 from typing import Any
 
 from django.db.models import Count, Max
-from django.http import FileResponse
+from django.http import FileResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import generics, permissions, status
@@ -59,8 +59,10 @@ from .services import (
     can_view_thread,
     filter_visible_files,
     filter_visible_threads,
+    folder_subtree_ids,
     member_subgroup_ids,
     remove_member,
+    visible_folder_ids,
     visible_threads_q,
 )
 
@@ -911,7 +913,8 @@ class FolderListCreateView(generics.ListCreateAPIView):
     def get_queryset(self) -> Any:
         subgroup = get_object_or_404(Subgroup, slug=self.kwargs["slug"])
         parent_id = self.request.query_params.get("parent")
-        queryset = Folder.objects.filter(subgroup=subgroup)
+        visible_ids = visible_folder_ids(self.request.user, subgroup)
+        queryset = Folder.objects.filter(subgroup=subgroup, id__in=visible_ids)
         if parent_id:
             queryset = queryset.filter(parent_id=parent_id)
         else:
@@ -922,15 +925,96 @@ class FolderListCreateView(generics.ListCreateAPIView):
         context = super().get_serializer_context()
         if self.request.method == "POST":
             context["subgroup"] = get_object_or_404(Subgroup, slug=self.kwargs["slug"])
+        elif self.request.method == "GET":
+            subgroup = get_object_or_404(Subgroup, slug=self.kwargs["slug"])
+            context["visible_folder_ids"] = visible_folder_ids(self.request.user, subgroup)
         return context
 
+    def perform_create(self, serializer: Any) -> None:
+        # In a members-only subgroup, only formal members may create folders —
+        # otherwise the creator (a non-member) would be unable to see their
+        # own folder, and the directory structure is members' territory.
+        # Open subgroups have no privacy boundary, so anyone authenticated can
+        # create folders (consistent with anyone being able to upload files).
+        subgroup = get_object_or_404(Subgroup, slug=self.kwargs["slug"])
+        if subgroup.allows_members:
+            user = self.request.user
+            is_member = SubgroupMembership.objects.filter(user=user, subgroup=subgroup).exists()
+            if not is_member:
+                from rest_framework.exceptions import PermissionDenied
 
-class FolderDetailView(generics.RetrieveAPIView):
-    """Get folder details with files."""
+                raise PermissionDenied("Kun medlemmer af gruppen kan oprette mapper.")
+        serializer.save()
+
+
+class FolderDetailView(generics.RetrieveDestroyAPIView):
+    """Get folder details, or delete a folder and all its contents."""
 
     serializer_class = FolderSerializer
     permission_classes = [permissions.IsAuthenticated]
-    queryset = Folder.objects.all()
+
+    def get_queryset(self) -> Any:
+        return Folder.objects.all()
+
+    def get_object(self) -> Folder:
+        folder = get_object_or_404(Folder, pk=self.kwargs["pk"])
+        if folder.subgroup_id is not None:
+            visible_ids = visible_folder_ids(self.request.user, folder.subgroup)
+            if folder.id not in visible_ids:
+                raise Http404
+        return folder
+
+    def perform_destroy(self, instance: Folder) -> None:
+        # Same gate as folder creation: in members-only subgroups, only members
+        # may delete; in open subgroups any authenticated user may.
+        subgroup = instance.subgroup
+        if subgroup is not None and subgroup.allows_members:
+            user = self.request.user
+            is_member = SubgroupMembership.objects.filter(user=user, subgroup=subgroup).exists()
+            if not is_member:
+                from rest_framework.exceptions import PermissionDenied
+
+                raise PermissionDenied("Kun medlemmer af gruppen kan slette mapper.")
+
+        # Django's CASCADE does bulk SQL DELETE on descendant files, which
+        # bypasses File.delete() and leaks blobs on disk. Walk the subtree and
+        # delete files individually so storage cleanup runs, then drop the
+        # folder (cascade handles the remaining empty subfolders).
+        for f in File.objects.filter(folder_id__in=folder_subtree_ids(instance)):
+            f.delete()
+
+        instance.delete()
+
+
+class FolderDeletePreviewView(APIView):
+    """Return how many subfolders and files would be deleted with this folder.
+
+    Used by the delete-confirmation UI to inform the user about the cascade
+    impact before they confirm. Gated by the same rule as folder deletion so
+    we don't expose counts to users who couldn't delete the folder anyway.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request: Request, pk: int) -> Response:
+        folder = get_object_or_404(Folder, pk=pk)
+        subgroup = folder.subgroup
+        if subgroup is not None and subgroup.allows_members:
+            is_member = SubgroupMembership.objects.filter(
+                user=request.user, subgroup=subgroup
+            ).exists()
+            if not is_member:
+                from rest_framework.exceptions import PermissionDenied
+
+                raise PermissionDenied("Kun medlemmer af gruppen kan slette mapper.")
+
+        ids = folder_subtree_ids(folder)
+        return Response(
+            {
+                "file_count": File.objects.filter(folder_id__in=ids).count(),
+                "subfolder_count": len(ids) - 1,
+            }
+        )
 
 
 class FolderBySlugView(generics.RetrieveAPIView):
@@ -941,7 +1025,11 @@ class FolderBySlugView(generics.RetrieveAPIView):
 
     def get_object(self) -> Folder:
         subgroup = get_object_or_404(Subgroup, slug=self.kwargs["slug"])
-        return get_object_or_404(Folder, subgroup=subgroup, slug=self.kwargs["folder_slug"])
+        folder = get_object_or_404(Folder, subgroup=subgroup, slug=self.kwargs["folder_slug"])
+        visible_ids = visible_folder_ids(self.request.user, subgroup)
+        if folder.id not in visible_ids:
+            raise Http404
+        return folder
 
 
 # File Views
@@ -1096,6 +1184,10 @@ class FolderDownloadView(APIView):
 
     def get(self, request: Request, pk: int) -> FileResponse | Response:
         folder = get_object_or_404(Folder, pk=pk)
+        if folder.subgroup_id is not None:
+            visible_ids = visible_folder_ids(request.user, folder.subgroup)
+            if folder.id not in visible_ids:
+                raise Http404
 
         buf = io.BytesIO()
         total_size = 0

--- a/frontend/src/api/forum.ts
+++ b/frontend/src/api/forum.ts
@@ -30,6 +30,11 @@ export interface GetThreadsOptions {
   isClosed?: boolean
 }
 
+export interface FolderDeletePreview {
+  file_count: number
+  subfolder_count: number
+}
+
 interface SubgroupUpdateData {
   name?: string
 
@@ -489,6 +494,20 @@ export const forumApi = {
 
         parent: parentId || null,
       },
+    )
+
+    return response.data
+  },
+
+  deleteFolder: async (folderId: number): Promise<void> => {
+    await apiClient.delete(`/forum/folders/${folderId}/`)
+  },
+
+  getFolderDeletePreview: async (
+    folderId: number,
+  ): Promise<FolderDeletePreview> => {
+    const response = await apiClient.get(
+      `/forum/folders/${folderId}/delete-preview/`,
     )
 
     return response.data

--- a/frontend/src/pages/SubgroupPage.tsx
+++ b/frontend/src/pages/SubgroupPage.tsx
@@ -31,6 +31,7 @@ import {
   Checkbox,
   Tooltip,
   Menu,
+  Alert,
 } from "@mantine/core"
 
 import { useDisclosure, useMediaQuery } from "@mantine/hooks"
@@ -862,6 +863,7 @@ Then each seperate ${capitalize(actionVerb)} is implemented one at a time where 
           <DocumentsTab
             subgroupSlug={slug!}
             allowsMembers={subgroup?.allows_members ?? false}
+            isMember={subgroup?.is_member ?? false}
             defaultMembersOnly={subgroup?.default_members_only ?? false}
             initialFolderSlug={initialFolderSlug}
             onFolderChange={(folderSlug) => {
@@ -1413,6 +1415,8 @@ interface DocumentsTabProps {
 
   allowsMembers: boolean
 
+  isMember: boolean
+
   defaultMembersOnly: boolean
 
   initialFolderSlug?: string | null
@@ -1424,6 +1428,8 @@ function DocumentsTab({
   subgroupSlug,
 
   allowsMembers,
+
+  isMember,
 
   defaultMembersOnly,
 
@@ -1734,6 +1740,63 @@ function DocumentsTab({
     onFolderChange?.(folderSlug ?? null)
   }
 
+  const [
+    deleteFolderConfirmOpened,
+    { open: openDeleteFolderConfirmRaw, close: closeDeleteFolderConfirm },
+  ] = useDisclosure(false)
+
+  const canDeleteCurrentFolder =
+    currentFolderId !== null && (!allowsMembers || isMember)
+
+  const currentFolderName =
+    folderPath[folderPath.length - 1]?.name ?? "denne mappe"
+
+  const [deleteConfirmName, setDeleteConfirmName] = useState("")
+
+  const openDeleteFolderConfirm = () => {
+    setDeleteConfirmName("")
+    openDeleteFolderConfirmRaw()
+  }
+
+  const {
+    data: deletePreview,
+    isFetching: deletePreviewFetching,
+    isError: deletePreviewError,
+  } = useQuery({
+    queryKey: ["folder-delete-preview", currentFolderId],
+    queryFn: () =>
+      currentFolderId !== null
+        ? forumApi.getFolderDeletePreview(currentFolderId)
+        : Promise.resolve(null),
+    enabled: deleteFolderConfirmOpened && currentFolderId !== null,
+    staleTime: 0,
+  })
+
+  const deleteFolderMutation = useMutation({
+    mutationFn: () => {
+      if (currentFolderId === null) return Promise.resolve()
+      return forumApi.deleteFolder(currentFolderId)
+    },
+    onSuccess: () => {
+      notifications.show({
+        title: "Mappe slettet",
+        message: `Mappen "${currentFolderName}" og dens indhold er slettet.`,
+        color: "green",
+      })
+      const parent =
+        folderPath.length >= 2 ? folderPath[folderPath.length - 2] : null
+      navigateToFolder(
+        parent?.id ?? null,
+        parent?.name ?? "Dokumenter",
+        parent?.slug,
+      )
+      queryClient.invalidateQueries({ queryKey: ["folders", subgroupSlug] })
+    },
+    onError: (error: unknown) => {
+      showErrorNotification(error, "Kunne ikke slette mappen. Prøv igen.")
+    },
+  })
+
   const isLoading = resolvingSlug || foldersLoading || filesLoading
 
   const hasContent =
@@ -1780,6 +1843,17 @@ function DocumentsTab({
                 size="sm"
               />
             </Tooltip>
+          )}
+          {canDeleteCurrentFolder && (
+            <Button
+              variant="light"
+              color="red"
+              leftSection={<IconTrash size={16} />}
+              onClick={openDeleteFolderConfirm}
+              size="sm"
+            >
+              Slet mappe
+            </Button>
           )}
           <Button
             variant="light"
@@ -1897,6 +1971,65 @@ function DocumentsTab({
           closeCreateFolderModal()
         }}
       />
+
+      <Modal
+        opened={deleteFolderConfirmOpened}
+        onClose={closeDeleteFolderConfirm}
+        title="Slet mappe"
+        centered
+        size="sm"
+      >
+        <Stack gap="md">
+          <Alert color="red" variant="light">
+            <Stack gap="xs">
+              <Text>
+                Er du sikker på, at du vil slette mappen "{currentFolderName}"
+                og alt dens indhold? Denne handling kan ikke fortrydes.
+              </Text>
+              {deletePreview ? (
+                <Text size="sm">
+                  Dette vil slette {deletePreview.subfolder_count}{" "}
+                  {deletePreview.subfolder_count === 1
+                    ? "undermappe"
+                    : "undermapper"}{" "}
+                  og {deletePreview.file_count}{" "}
+                  {deletePreview.file_count === 1 ? "fil" : "filer"}.
+                </Text>
+              ) : deletePreviewError ? (
+                <Text size="sm">Kunne ikke hente antal filer/mapper.</Text>
+              ) : (
+                <Text size="sm" c="dimmed">
+                  {deletePreviewFetching
+                    ? "Henter antal filer og mapper..."
+                    : ""}
+                </Text>
+              )}
+            </Stack>
+          </Alert>
+          <TextInput
+            label={`Skriv "${currentFolderName}" for at bekræfte`}
+            value={deleteConfirmName}
+            onChange={(e) => setDeleteConfirmName(e.currentTarget.value)}
+            data-autofocus
+          />
+          <Group justify="flex-end">
+            <Button variant="light" onClick={closeDeleteFolderConfirm}>
+              Annuller
+            </Button>
+            <Button
+              color="red"
+              disabled={deleteConfirmName !== currentFolderName}
+              onClick={() => {
+                closeDeleteFolderConfirm()
+                deleteFolderMutation.mutate()
+              }}
+              loading={deleteFolderMutation.isPending}
+            >
+              Slet
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </FileDropzone>
   )
 }


### PR DESCRIPTION
## Summary

- **Hide private folders from non-members.** Previously, folders containing only `members_only=True` files were visible to non-members of the subgroup, leaking the directory structure (folder names, hierarchy, counts) even though the files themselves were correctly hidden. A folder is now shown to a non-member only if it (or any descendant) contains a file the user can view.
- **Gate folder management to members.** In members-only subgroups, only formal members can create or delete folders. In open subgroups, any authenticated user can — matching existing file-upload rules. File upload behavior is unchanged.
- **Folder deletion.** Adds `DELETE /api/forum/folders/<pk>/`. Walks the subtree and calls `File.delete()` on each descendant so storage cleanup runs (Django's `CASCADE` does bulk SQL DELETE and bypasses `Model.delete()`, leaking blobs on disk).
- **Delete-preview endpoint.** `GET /api/forum/folders/<pk>/delete-preview/` returns `{file_count, subfolder_count}` for the entire subtree — used by the confirmation UI to show the cascade impact.
- **Confirmation modal.** "Slet mappe" button appears in the folder header. Modal shows recursive counts inside a red Alert and requires the user to type the folder's name to enable the delete button.
- **Duplicate-name guard.** Blocks creation of folders with duplicate names under the same parent. The model's `UniqueConstraint(subgroup, parent, name)` doesn't enforce this for root folders because SQLite (and PostgreSQL by default) treats NULL parents as distinct. Validation in `FolderCreateSerializer` returns a clean 400 with a field-level error in Danish.

## Test plan

- [x] `cd backend && uv run pytest` — 559 passed
- [x] `cd backend && uv run ruff check . && uv run ruff format --check .` — clean
- [x] `cd frontend && npm run typecheck && npm run lint && npm run format:check && npm run test:run` — clean, 386 tests passed
- [ ] Manual smoke test: as a non-member, confirm folders containing only private files no longer appear in members-only subgroups; as a member, confirm all folders (including empty newly-created ones) remain visible.
- [ ] Manual smoke test: enter a folder, click "Slet mappe", verify the modal shows correct subfolder/file counts and the Slet button stays disabled until the folder name is typed exactly.
- [ ] Manual smoke test: try to create a folder with a name that already exists at the same level — verify a Danish error notification appears.
- [ ] Manual smoke test: as a non-member of a private subgroup, attempt to create or delete a folder — verify 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)