### PR TITLE
Bugfix batch: forum, carousel, calendar, announcements

### DIFF
--- a/backend/apps/forum/serializers.py
+++ b/backend/apps/forum/serializers.py
@@ -287,6 +287,11 @@ class PollOptionCreateSerializer(serializers.Serializer):
 
     text = serializers.CharField(max_length=200)
 
+    def validate_text(self, value: str) -> str:
+        if not value.strip():
+            raise serializers.ValidationError("Valgmulighed må ikke være tom.")
+        return value
+
 
 class PollCreateSerializer(serializers.Serializer):
     """Serializer for creating a poll."""
@@ -309,6 +314,11 @@ class PollOptionUpdateSerializer(serializers.Serializer):
 
     id = serializers.IntegerField(required=False, allow_null=True)
     text = serializers.CharField(max_length=200)
+
+    def validate_text(self, value: str) -> str:
+        if not value.strip():
+            raise serializers.ValidationError("Valgmulighed må ikke være tom.")
+        return value
 
 
 class PollUpdateSerializer(serializers.Serializer):

--- a/frontend/src/components/AttachmentCarousel.tsx
+++ b/frontend/src/components/AttachmentCarousel.tsx
@@ -290,6 +290,8 @@ function SlideContent({ attachment, isMobile, opened }: SlideContentProps) {
             maxHeight: isMobile ? "calc(100vh - 140px)" : "65vh",
 
             maxWidth: "100%",
+
+            touchAction: "pan-y pinch-zoom",
           }}
         />
         <Group justify="center" mt="md">

--- a/frontend/src/pages/AnnouncementsPage.tsx
+++ b/frontend/src/pages/AnnouncementsPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 
-import { useLocation } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 
@@ -77,9 +77,11 @@ import type {
 export default function AnnouncementsPage() {
   const queryClient = useQueryClient()
 
-  const { hash } = useLocation()
+  const location = useLocation()
 
-  const scrolledRef = useRef("")
+  const navigate = useNavigate()
+
+  const { hash } = location
 
   const [
     createModalOpened,
@@ -123,24 +125,20 @@ export default function AnnouncementsPage() {
     })
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Scroll to and highlight a specific announcement when navigating from search
+  // Scroll to and highlight a specific announcement when navigating from a
+  // notification or search result. Clear the hash through React Router so a
+  // subsequent click on the same notification re-fires this effect.
 
   useEffect(() => {
-    if (!hash || !announcements || scrolledRef.current === hash) return
+    if (!hash || !announcements) return
 
     const el = document.getElementById(hash.slice(1))
 
     if (!el) return
 
-    const currentHash = hash
-
-    window.history.replaceState(null, "", window.location.pathname)
+    navigate(location.pathname + location.search, { replace: true })
 
     const timer = setTimeout(() => {
-      if (scrolledRef.current === currentHash) return
-
-      scrolledRef.current = currentHash
-
       el.scrollIntoView({ behavior: "smooth", block: "center" })
 
       el.style.borderRadius = "var(--mantine-radius-md)"
@@ -155,7 +153,7 @@ export default function AnnouncementsPage() {
     }, 100)
 
     return () => clearTimeout(timer)
-  }, [hash, announcements])
+  }, [hash, announcements, navigate, location.pathname, location.search])
 
   const deleteMutation = useMutation({
     mutationFn: announcementsApi.deleteAnnouncement,

--- a/frontend/src/pages/EventFormPage.tsx
+++ b/frontend/src/pages/EventFormPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react"
+import { useState, useMemo, useEffect, useRef } from "react"
 
 import { useParams, useNavigate, useSearchParams } from "react-router-dom"
 
@@ -207,6 +207,7 @@ export default function EventFormPage() {
   const [endTime, setEndTime] = useState("")
 
   const [stedTags, setStedTags] = useState<string[]>([])
+  const stedInputRef = useRef<HTMLInputElement>(null)
 
   const [subgroupId, setSubgroupId] = useState<string | null>(null)
 
@@ -943,6 +944,7 @@ export default function EventFormPage() {
             )}
 
             <TagsInput
+              ref={stedInputRef}
               label="Sted"
               placeholder="Vælg lokale eller skriv sted"
               leftSection={<IconMapPin size={16} />}
@@ -952,6 +954,11 @@ export default function EventFormPage() {
                 clearErrors()
 
                 setStedTags(value)
+
+                // Most users only pick one location; blur to dismiss the
+                // dropdown so they don't have to click outside. Defer
+                // because Mantine refocuses the input after a select.
+                setTimeout(() => stedInputRef.current?.blur(), 0)
               }}
               error={errors.room_ids || errors.location}
               clearable

--- a/frontend/src/pages/ForumPage.tsx
+++ b/frontend/src/pages/ForumPage.tsx
@@ -506,17 +506,19 @@ function SubgroupCard({
         </Box>
       )}
       <Stack gap="sm">
-        <Group justify="space-between">
-          <Group gap="xs">
+        <Group justify="space-between" wrap="nowrap" align="flex-start">
+          <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
             {subgroup.icon && (
-              <Text size="lg" lh={1}>
+              <Text size="lg" lh={1} style={{ flexShrink: 0 }}>
                 {subgroup.icon}
               </Text>
             )}
-            <Text fw={500}>{subgroup.name}</Text>
+            <Text fw={500} style={{ wordBreak: "break-word" }}>
+              {subgroup.name}
+            </Text>
           </Group>
           {!hideBell && (
-            <Group gap="xs">
+            <Group gap="xs" style={{ flexShrink: 0 }}>
               <Tooltip
                 label={subgroup.is_subscribed ? "Afmeld" : "Abonnér"}
                 withArrow

--- a/frontend/src/pages/HouseEditPage.tsx
+++ b/frontend/src/pages/HouseEditPage.tsx
@@ -79,6 +79,8 @@ export default function HouseEditPage() {
 
   const [description, setDescription] = useState("")
 
+  const [isEditingDescription, setIsEditingDescription] = useState(false)
+
   const [editingChild, setEditingChild] = useState<Child | null>(null)
 
   const [childModalOpened, { open: openChildModal, close: closeChildModal }] =
@@ -143,6 +145,8 @@ export default function HouseEditPage() {
       queryClient.invalidateQueries({ queryKey: ["house"] })
 
       queryClient.invalidateQueries({ queryKey: ["houses"] })
+
+      setIsEditingDescription(false)
 
       notifications.show({
         title: "Hus opdateret",
@@ -588,27 +592,63 @@ export default function HouseEditPage() {
       </Paper>
 
       <Paper withBorder p="xl" radius="md" mb="xl">
-        <form onSubmit={handleSubmit}>
+        {isEditingDescription ? (
+          <form onSubmit={handleSubmit}>
+            <Stack>
+              <Title order={4}>Beskrivelse</Title>
+
+              <Textarea
+                label="Om husstanden"
+                placeholder="Fortæl lidt om jeres husstand..."
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                minRows={3}
+                maxLength={1000}
+                description={`${description.length}/1000 tegn`}
+                autoFocus
+              />
+
+              <Group justify="flex-end" mt="md">
+                <Button
+                  variant="subtle"
+                  onClick={() => {
+                    setDescription(house.description || "")
+                    setIsEditingDescription(false)
+                  }}
+                  disabled={updateHouseMutation.isPending}
+                >
+                  Annuller
+                </Button>
+                <Button type="submit" loading={updateHouseMutation.isPending}>
+                  Gem ændringer
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        ) : (
           <Stack>
-            <Title order={4}>Beskrivelse</Title>
-
-            <Textarea
-              label="Om husstanden"
-              placeholder="Fortæl lidt om jeres husstand..."
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              minRows={3}
-              maxLength={1000}
-              description={`${description.length}/1000 tegn`}
-            />
-
-            <Group justify="flex-end" mt="md">
-              <Button type="submit" loading={updateHouseMutation.isPending}>
-                Gem ændringer
+            <Group justify="space-between" align="flex-start">
+              <Title order={4}>Beskrivelse</Title>
+              <Button
+                variant="subtle"
+                leftSection={<IconPencil size={16} />}
+                onClick={() => setIsEditingDescription(true)}
+              >
+                Rediger
               </Button>
             </Group>
+
+            {house.description ? (
+              <Text style={{ whiteSpace: "pre-wrap" }}>
+                {house.description}
+              </Text>
+            ) : (
+              <Text c="dimmed" fs="italic">
+                Ingen beskrivelse endnu.
+              </Text>
+            )}
           </Stack>
-        </form>
+        )}
       </Paper>
 
       <Paper withBorder p="xl" radius="md">

--- a/frontend/src/pages/SubgroupPage.tsx
+++ b/frontend/src/pages/SubgroupPage.tsx
@@ -572,7 +572,7 @@ Then each seperate ${capitalize(actionVerb)} is implemented one at a time where 
 
   return (
     <>
-      <BackButton to="/forum" label="Tilbage til forum" />
+      <BackButton to="/forum" label="Tilbage til forumoversigt" />
 
       <Modal
         opened={editGroupOpened}

--- a/frontend/src/pages/SubgroupPage.tsx
+++ b/frontend/src/pages/SubgroupPage.tsx
@@ -1243,6 +1243,15 @@ function CreateThreadModal({
 
     if (!title.trim() || !content.trim()) return
 
+    if (pollData?.options.some((o) => !o.text.trim())) {
+      notifications.show({
+        title: "Tomme valgmuligheder",
+        message: "Alle valgmuligheder i afstemningen skal have tekst.",
+        color: "red",
+      })
+      return
+    }
+
     createMutation.mutate({
       data: {
         title: title.trim(),

--- a/frontend/src/pages/SubgroupPage.tsx
+++ b/frontend/src/pages/SubgroupPage.tsx
@@ -2632,6 +2632,43 @@ function CreateFolderModal({
   )
 }
 
+interface FolderOption {
+  value: string
+  label: string
+}
+
+function buildFolderOptions(folders: Folder[] | undefined): FolderOption[] {
+  const root: FolderOption = {
+    value: "root",
+    label: "📁 Rodmappe (ingen mappe)",
+  }
+  if (!folders || folders.length === 0) {
+    return [root]
+  }
+
+  const byParent = new Map<number | null, Folder[]>()
+  for (const f of folders) {
+    const arr = byParent.get(f.parent) ?? []
+    arr.push(f)
+    byParent.set(f.parent, arr)
+  }
+  for (const arr of byParent.values()) {
+    arr.sort((a, b) => a.name.localeCompare(b.name, "da"))
+  }
+
+  const out: FolderOption[] = [root]
+  const walk = (parentId: number | null, depth: number) => {
+    const children = byParent.get(parentId) ?? []
+    for (const f of children) {
+      const indent = "    ".repeat(depth)
+      out.push({ value: f.id.toString(), label: `${indent}📂 ${f.name}` })
+      walk(f.id, depth + 1)
+    }
+  }
+  walk(null, 0)
+  return out
+}
+
 interface MoveFileModalProps {
   opened: boolean
 
@@ -2702,17 +2739,7 @@ function MoveFileModal({
     moveMutation.mutate()
   }
 
-  // Build folder options with hierarchy indication
-
-  const folderOptions = [
-    { value: "root", label: "📁 Rodmappe (ingen mappe)" },
-
-    ...(folders?.map((folder) => ({
-      value: folder.id.toString(),
-
-      label: `📂 ${folder.name}`,
-    })) ?? []),
-  ]
+  const folderOptions = buildFolderOptions(folders)
 
   return (
     <Modal opened={opened} onClose={onClose} title={`Flyt "${file.name}"`}>

--- a/frontend/src/pages/ThreadPage.tsx
+++ b/frontend/src/pages/ThreadPage.tsx
@@ -169,6 +169,15 @@ const ReplyForm = memo(function ReplyForm({
 
     if (isEmpty) return
 
+    if (pollData?.options.some((o) => !o.text.trim())) {
+      notifications.show({
+        title: "Tomme valgmuligheder",
+        message: "Alle valgmuligheder i afstemningen skal have tekst.",
+        color: "red",
+      })
+      return
+    }
+
     onSubmit(content.trim(), attachments, pollData || undefined)
   }
 
@@ -759,6 +768,15 @@ export default function ThreadPage() {
     const isFirstPost = thread && editingPost.id === thread.posts[0]?.id
 
     if (isFirstPost && !editTitle.trim()) return
+
+    if (editPollData?.options.some((o) => !o.text.trim())) {
+      notifications.show({
+        title: "Tomme valgmuligheder",
+        message: "Alle valgmuligheder i afstemningen skal have tekst.",
+        color: "red",
+      })
+      return
+    }
 
     updatePostMutation.mutate({
       postId: editingPost.id,

--- a/frontend/src/pages/ThreadPage.tsx
+++ b/frontend/src/pages/ThreadPage.tsx
@@ -808,7 +808,7 @@ export default function ThreadPage() {
     <>
       <BackButton
         to={`/forum/${thread.subgroup_slug}`}
-        label="Tilbage til forum"
+        label={`Tilbage til ${thread.subgroup_name}`}
       />
 
       {thread.posts[0] && (

--- a/frontend/src/pages/bookings/BookingModals.tsx
+++ b/frontend/src/pages/bookings/BookingModals.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react"
+import { useState, useMemo, useEffect, useRef } from "react"
 
 import { useMutation } from "@tanstack/react-query"
 
@@ -153,6 +153,7 @@ export function CreateBookingModal({
   onSuccess,
 }: CreateBookingModalProps) {
   const [selectedRoomIds, setSelectedRoomIds] = useState<string[]>([])
+  const roomsInputRef = useRef<HTMLInputElement>(null)
 
   const [title, setTitle] = useState("")
 
@@ -344,11 +345,19 @@ export function CreateBookingModal({
       <form onSubmit={handleSubmit}>
         <Stack gap="md">
           <MultiSelect
+            ref={roomsInputRef}
             label="Lokaler"
             placeholder="Vælg et eller flere lokaler"
             data={roomOptions}
             value={selectedRoomIds}
-            onChange={setSelectedRoomIds}
+            onChange={(value) => {
+              setSelectedRoomIds(value)
+
+              // Most users only pick one room; blur to dismiss the
+              // dropdown so they don't have to click outside. Defer
+              // because Mantine refocuses the input after a select.
+              setTimeout(() => roomsInputRef.current?.blur(), 0)
+            }}
             searchable
             required
           />


### PR DESCRIPTION
## Summary

Bundle of four small bug fixes from a "Bugs" forum-group handoff. Each fix
is a standalone commit so they can be reverted individually if needed.

| Commit | Area | Bug |
|---|---|---|
| 6c093ac | Forum | Move-file picker rendered nested folders flat |
| 535950b | Forum | Pinch-zoom blocked on attachment-carousel images |
| 2315fd0 | Calendar | Location dropdown stayed open after a pick |
| d996e59 | Announcements | "Opdateret:" notifications didn't scroll/highlight |

## Details

### 6c093ac — Forum: show folder hierarchy in move-file picker
`SubgroupPage.tsx` `MoveFileModal` showed folders as a flat list, so two
folders called e.g. "Bilag" at different depths were indistinguishable.
Added `buildFolderOptions(folders)` helper that walks the parent-id tree,
sorts each level alphabetically (Danish locale), and prefixes labels with
non-breaking-space indentation. Root entry stays on top.

**Caveat:** if a folder's parent is missing from the returned list (e.g.
filtered by permissions), that folder will not appear in the picker.
Old code rendered everything regardless. `forumApi.getAllFolders` is
expected to return a complete subtree, so this should be a non-issue —
but worth knowing.

### 535950b — Forum: allow pinch-zoom on attachment images
`index.css` sets `touch-action: manipulation` globally on `:root`, which
blocks pinch-zoom. `AttachmentCarousel.tsx` slide image now overrides
this with `touch-action: pan-y pinch-zoom`, leaving Embla's horizontal
swipe-to-next-slide intact.

**Caveats (not yet verified on a real device):**
- Once zoomed in, two-finger panning of the image may interact awkwardly
  with horizontal slide swipes (browser pinch-zoom is viewport-level,
  not element-level).
- A more polished UX would use a dedicated lightbox/zoom library
  (e.g. `yet-another-react-lightbox` + zoom plugin) — left as follow-up.

### 2315fd0 — Calendar: auto-close location dropdown after a pick
The "Sted" `TagsInput` on `EventFormPage.tsx` and the "Lokaler"
`MultiSelect` on the create-`BookingModals.tsx` both stayed open after
the user picked a value. Most users only pick one location, so we
`blur()` the input from `onChange`. The blur is wrapped in
`setTimeout(..., 0)` because Mantine refocuses the input after a select,
which would otherwise cancel a synchronous blur.

**Behavioural note:** multi-select still works (re-focus to add more).
Users typing multiple free-form locations need to re-focus after each
commit. Matches the assumption "most users only pick one".

### d996e59 — Announcements: re-scroll/re-highlight on repeat hash nav
Clicking an "Opdateret:" notification opened `/opslag` at the top
instead of scrolling to the announcement and flashing the blue ring.
Root cause: the effect cleared the URL hash via
`window.history.replaceState`, which bypasses React Router. React
Router's internal `location.hash` was still `#announcement-X`, so a
second click for the same announcement looked like a no-op and the
effect never re-fired. Routes the clear through `navigate(...)` so the
hash state stays in sync, and drops the `scrolledRef` guard that also
suppressed re-scroll.

Backend (`notify_announcement_updated` in
`notifications/services.py`) already builds the correct
`/opslag#announcement-<id>` link — no backend change needed.

## Test plan

- [ ] Bug 5: open a subgroup with nested folders → click a file → "Flyt" → confirm folder picker shows indentation per nesting level
- [ ] Bug 6: open an image attachment from the forum on a real phone → confirm pinch-zoom works; check that horizontal swipe between slides still works at zoom = 1
- [ ] Bug 7 (event form): create/edit a calendar event → click "Sted" → pick a room → confirm dropdown closes
- [ ] Bug 7 (booking modal): open booking calendar → "Opret booking" → pick a room from "Lokaler" → confirm dropdown closes
- [ ] Bug 8: trigger an announcement update so the recipient gets an "Opdateret:" notification → click it → page should scroll to the announcement and flash blue, on first **and** repeat clicks

## Verification status

- Lint, format, typecheck pass on every commit
- Bug 7 (event form path) was manually verified on the fork
- Bug 7 (booking modal path), Bug 6, Bug 5, Bug 8 still need manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)