### PR TITLE
Forum: auto-load threads on scroll

### DIFF
--- a/frontend/src/pages/SubgroupPage.tsx
+++ b/frontend/src/pages/SubgroupPage.tsx
@@ -127,6 +127,8 @@ interface CreateThreadParams {
   pollData?: CreatePollData
 }
 
+const THREADS_PAGE_SIZE = 50
+
 export default function SubgroupPage() {
   const { slug, folderSlug: folderSlugParam } = useParams<{
     slug: string
@@ -185,15 +187,36 @@ export default function SubgroupPage() {
     queryFn: ({ pageParam = 1 }) =>
       forumApi.getThreads(slug!, {
         page: pageParam,
+        pageSize: THREADS_PAGE_SIZE,
         ...(hideClosedThreads ? { isClosed: false } : {}),
       }),
     getNextPageParam: (lastPage) => parsePageParam(lastPage.next),
     initialPageParam: 1,
     enabled: !!slug,
+    gcTime: 30_000,
   })
 
   const threads = (threadsQuery.data?.pages ?? []).flatMap((p) => p.results)
   const threadsLoading = threadsQuery.isLoading
+
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = threadsQuery
+  useEffect(() => {
+    const node = loadMoreRef.current
+    if (!node) return
+    if (!hasNextPage) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage()
+        }
+      },
+      { rootMargin: "400px" },
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
 
   const { data: upcomingEvents } = useQuery({
     queryKey: ["events", "subgroup", subgroup?.id],
@@ -795,6 +818,9 @@ Then each seperate ${capitalize(actionVerb)} is implemented one at a time where 
                   }
                 />
               ))
+            )}
+            {threadsQuery.hasNextPage && (
+              <div ref={loadMoreRef} aria-hidden="true" />
             )}
             {threadsQuery.hasNextPage && (
               <Center mt="sm">


### PR DESCRIPTION
## Summary
- Bumps the threads page size from 20 to 50 on `SubgroupPage`.
- Adds an `IntersectionObserver` sentinel near the bottom so the next page auto-loads on scroll — no more clicking "Vis flere tråde" 100 times. The button stays as a fallback.
- Shortens the threads `gcTime` to 30s so a long accumulated list doesn't linger in cache (and trigger a heavy background refetch of every loaded page) when navigating back.

## Test plan
- [x] Open a subgroup with > 50 threads — first page shows 50.
- [x] Scroll down — next 50 auto-append before reaching the button; repeat to the bottom.
- [ ] Toggle "skjul lukkede tråde" — list resets and auto-load still works.
- [ ] Open a subgroup with < 50 threads — no button or sentinel renders.
- [ ] Leave the subgroup for > 30s and return — list rehydrates with only the first 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)