### PR TITLE
Forum: trigger thread auto-load earlier

### DIFF
--- a/frontend/src/pages/SubgroupPage.tsx
+++ b/frontend/src/pages/SubgroupPage.tsx
@@ -212,7 +212,7 @@ export default function SubgroupPage() {
           fetchNextPage()
         }
       },
-      { rootMargin: "400px" },
+      { rootMargin: "1500px" },
     )
     observer.observe(node)
     return () => observer.disconnect()


### PR DESCRIPTION
## Summary
- Bumps the IntersectionObserver `rootMargin` from `400px` to `1500px` on the threads sentinel in `SubgroupPage`.
- The next page now starts loading roughly 1.5 viewport-heights before the sentinel enters view, so new threads stream in mid-scroll instead of only appearing once the user reaches the bottom.

## Test plan
- [x] Open a subgroup with ≥ 100 threads.
- [x] Scroll down — by the time you've passed ~30 threads, the next batch of 50 has already loaded (no visible button blip).
- [x] Continue scrolling to the bottom — auto-load chains seamlessly.
- [x] Verify nothing regresses on a subgroup with < 50 threads (no sentinel/button rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)