### PR TITLE
Forum: replies on closed threads auto-reopen them

### DIFF
--- a/backend/apps/forum/tests.py
+++ b/backend/apps/forum/tests.py
@@ -358,17 +358,18 @@ class TestThreadCloseViews:
         assert response.status_code == 200
         assert response.data["is_closed"] is True
 
-    def test_cannot_post_to_closed_thread(self, authenticated_client, thread):
-        """Test that posting to a closed thread is rejected."""
+    def test_post_to_closed_thread_reopens_it(self, authenticated_client, thread):
+        """Posting to a closed thread succeeds and auto-reopens the thread."""
         thread.is_closed = True
         thread.save()
 
         response = authenticated_client.post(
             f"/api/forum/threads/{thread.id}/posts/",
-            {"content": "This should fail"},
+            {"content": "Follow-up reply"},
         )
-        assert response.status_code == 403
-        assert "lukket" in response.data["detail"].lower()
+        assert response.status_code == 201
+        thread.refresh_from_db()
+        assert thread.is_closed is False
 
     def test_thread_detail_includes_closed_status(self, authenticated_client, thread):
         """Test that thread detail includes is_closed and can_close fields."""

--- a/backend/apps/forum/views.py
+++ b/backend/apps/forum/views.py
@@ -820,24 +820,23 @@ class PostListCreateView(generics.ListCreateAPIView):
         return context
 
     def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        """Override create to check if thread is closed."""
+        """Override create to enforce visibility (closed threads auto-reopen on reply)."""
         thread = get_object_or_404(Thread, pk=self.kwargs["thread_id"])
         if not can_view_thread(request.user, thread):
             from django.http import Http404
 
             raise Http404
-        if thread.is_closed:
-            return Response(
-                {"detail": "Denne tråd er lukket og accepterer ikke længere nye svar."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
         return super().create(request, *args, **kwargs)
 
     def perform_create(self, serializer: Any) -> None:
         serializer.save()
-        # Update thread's updated_at
         thread = get_object_or_404(Thread, pk=self.kwargs["thread_id"])
-        thread.save(update_fields=["updated_at"])
+        # A reply on a closed thread auto-reopens it.
+        update_fields = ["updated_at"]
+        if thread.is_closed:
+            thread.is_closed = False
+            update_fields.append("is_closed")
+        thread.save(update_fields=update_fields)
         # Send mention notifications (these take precedence — reply notifications
         # were already skipped for mentioned users in the serializer)
         from apps.notifications.tasks import notify_mentions_task

--- a/frontend/src/pages/ThreadPage.tsx
+++ b/frontend/src/pages/ThreadPage.tsx
@@ -472,6 +472,10 @@ export default function ThreadPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: threadQueryKey })
 
+      // Invalidate the subgroup thread list so the lock icon clears when
+      // a reply auto-reopens a closed thread.
+      queryClient.invalidateQueries({ queryKey: ["threads"] })
+
       clearDraft("reply-" + thread!.id)
 
       setReplySubmitKey((k) => k + 1)
@@ -1056,28 +1060,28 @@ export default function ThreadPage() {
 
       <Divider my="lg" />
 
-      {thread.is_closed ? (
+      {thread.is_closed && (
         <Paper
           withBorder
-          p="lg"
+          p="sm"
           radius="md"
           bg="var(--mantine-color-default-hover)"
+          mb="md"
         >
           <Group justify="center" gap="xs">
-            <IconLock size={20} color="var(--mantine-color-gray-6)" />
-            <Text c="dimmed">
-              Denne tråd er lukket og accepterer ikke længere nye svar.
+            <IconLock size={16} color="var(--mantine-color-gray-6)" />
+            <Text size="sm" c="dimmed">
+              Tråden er lukket — et nyt svar genåbner den.
             </Text>
           </Group>
         </Paper>
-      ) : (
-        <ReplyForm
-          threadId={thread.id}
-          onSubmit={handleReplySubmit}
-          isPending={createPostMutation.isPending}
-          submitKey={replySubmitKey}
-        />
       )}
+      <ReplyForm
+        threadId={thread.id}
+        onSubmit={handleReplySubmit}
+        isPending={createPostMutation.isPending}
+        submitKey={replySubmitKey}
+      />
 
       <Modal
         opened={deleteModalOpened}


### PR DESCRIPTION
## Summary
- Posting to a closed thread now succeeds and flips \`is_closed\` back to \`false\`. Removes the previous 403 in \`PostListCreateView.create\`.
- Reply form is always rendered. When the thread is closed, a small banner above it reads "Tråden er lukket — et nyt svar genåbner den."
- \`["threads"]\` cache is invalidated on reply so the subgroup-list lock icon clears immediately after auto-reopen.

## Why
Per Aske's feedback in the "Feature-idéer" subgroup: the original "lukket" semantic was inherited from the old intra to suppress mail spam. That concern is now handled by per-user notification preferences (\`notify_thread_replies\` etc.), so blocking follow-up replies is unnecessary friction. Closing a thread remains a useful "this is resolved" signal but is now advisory rather than enforcement.

## Behavior change worth noting
Closing is now advisory: any user who can view a thread can effectively reopen it by replying. If we ever need a true lock (moderation), that's a separate field/permission — not what \`is_closed\` represents anymore.

## Test plan
- [x] Backend: \`test_post_to_closed_thread_reopens_it\` (was \`test_cannot_post_to_closed_thread\`)
- [x] All 184 forum + notifications tests pass
- [x] All 386 frontend tests pass
- [ ] On prod: post to a closed thread, verify reply lands + thread reopens + lock badge clears in the subgroup list

🤖 Generated with [Claude Code](https://claude.com/claude-code)