### PR TITLE
Fix real-time new conversations and hover-action a11y noise

### DIFF
--- a/backend/apps/messaging/views.py
+++ b/backend/apps/messaging/views.py
@@ -196,6 +196,25 @@ class ConversationListCreateView(generics.ListCreateAPIView):
                     message_id=message.id,
                 )
 
+        # Notify other participants over WebSocket so their conversation list
+        # refreshes immediately and their socket joins the conversation group.
+        from asgiref.sync import async_to_sync
+        from channels.layers import get_channel_layer
+
+        channel_layer = get_channel_layer()
+        conversation_data = ConversationDetailSerializer(
+            conversation, context={"request": request}
+        ).data
+        for participant in conversation.participants.exclude(id=request.user.id):
+            async_to_sync(channel_layer.group_send)(
+                f"user_{participant.id}",
+                {
+                    "type": "new_conversation",
+                    "conversation_id": conversation.id,
+                    "conversation": conversation_data,
+                },
+            )
+
         return Response(
             ConversationDetailSerializer(conversation, context={"request": request}).data,
             status=status.HTTP_201_CREATED,

--- a/frontend/src/pages/MessagesPage.tsx
+++ b/frontend/src/pages/MessagesPage.tsx
@@ -1902,6 +1902,8 @@ const MessageBubble = memo(function MessageBubble({
     setCarouselOpened(true)
   }
 
+  const menuVisible = isMobileDevice || isHovered || menuOpened
+
   const menuButton = (
     <Menu
       opened={menuOpened}
@@ -1916,7 +1918,9 @@ const MessageBubble = memo(function MessageBubble({
           size="sm"
           color="gray"
           style={{
-            opacity: isMobileDevice || isHovered || menuOpened ? 1 : 0,
+            opacity: menuVisible ? 1 : 0,
+
+            pointerEvents: menuVisible ? "auto" : "none",
 
             transition: "opacity 0.1s",
 
@@ -1924,6 +1928,8 @@ const MessageBubble = memo(function MessageBubble({
           }}
           onMouseDown={(e) => e.preventDefault()}
           aria-label="Beskedindstillinger"
+          aria-hidden={!menuVisible}
+          tabIndex={menuVisible ? 0 : -1}
         >
           <IconDots size={14} />
         </ActionIcon>
@@ -1970,6 +1976,9 @@ const MessageBubble = memo(function MessageBubble({
     reactionMutation.mutate(emoji.native)
   }
 
+  const reactionVisible =
+    isHovered || reactionPickerOpened || fullEmojiPickerOpened
+
   const emojiPickerButton = (
     <>
       <Popover
@@ -1987,10 +1996,9 @@ const MessageBubble = memo(function MessageBubble({
             style={{
               display: isMobileDevice ? "none" : undefined,
 
-              opacity:
-                isHovered || reactionPickerOpened || fullEmojiPickerOpened
-                  ? 1
-                  : 0,
+              opacity: reactionVisible ? 1 : 0,
+
+              pointerEvents: reactionVisible ? "auto" : "none",
 
               transition: "opacity 0.1s",
 
@@ -2003,6 +2011,8 @@ const MessageBubble = memo(function MessageBubble({
               setReactionPickerOpened((o) => !o)
             }}
             aria-label="Tilføj reaktion"
+            aria-hidden={!reactionVisible}
+            tabIndex={reactionVisible ? 0 : -1}
           >
             <IconMoodSmile size={14} />
           </ActionIcon>


### PR DESCRIPTION
## Summary

Two fixes to the **Beskeder** (messages) feature, found via two-browser end-to-end testing:

- **Real-time new-conversation delivery (bug fix).** When a user started a brand-new conversation, the recipient's conversation list did not update over WebSocket — they saw only the unread badge tick up, and had to navigate away and back to see the conversation itself. `ConversationListCreateView.create()` now emits a `new_conversation` event to each non-creator participant's `user_<id>` channel group, mirroring the pattern already used by `AddParticipantsView`. The consumer auto-joins the recipient to the conversation channel, and the existing frontend handler invalidates the conversations query — so the new chat appears live with preview, unread badge, sidebar badge, and mail icon, with no reload required.

- **Hover-action a11y polish.** The per-message hover actions (Beskedindstillinger / Tilføj reaktion) faded in via `opacity` but stayed in the DOM, the accessibility tree, and the tab order. With N messages on screen, screen readers announced 2N copies of the same controls, keyboard users had to tab through invisible buttons, and the buttons captured stray clicks despite being invisible. `aria-hidden`, `tabIndex`, and `pointer-events` are now gated on the same visibility condition that drives `opacity`, so only the hovered message exposes its actions. Not visible to mouse + sighted use, but a real win for keyboard and screen-reader users.

## Test plan

- [x] Backend `pytest apps/messaging/` — 27/27, including create-conversation paths
- [x] Frontend `vitest run` — 386/386
- [x] `ruff check`, `ruff format --check`, `ty check` — pass on touched files
- [x] `tsgo`, `oxlint`, `oxfmt --check` — pass
- [x] Two-browser end-to-end on `localhost:5173`: Carl starts a new conversation with Johanne (who is parked on `/beskeder` with an empty list); the conversation appears live with preview text, unread badge, sidebar badge, and mail icon
- [x] Existing real-time flows still work: bidirectional message delivery in active conversations, list preview updates, read receipts (✓✓), emoji rendering
- [x] With four messages on screen, the accessibility snapshot shows zero pairs of hover-action buttons by default; hovering a message flips exactly that one pair's `aria-hidden` to `false` and `opacity` to 1

---

> P.S. TIL: `opacity: 0` is not a substitute for `aria-hidden`. Screen readers do not respect your CSS aesthetic choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)