### PR TITLE
Improve the giphy integration

### DIFF
--- a/frontend/src/components/ChatRichTextEditor.tsx
+++ b/frontend/src/components/ChatRichTextEditor.tsx
@@ -62,7 +62,7 @@ interface ChatRichTextEditorProps {
 
   onChange: (content: string) => void
 
-  onSend: () => void
+  onSend: (contentOverride?: string) => void
 
   placeholder?: string
 
@@ -448,15 +448,15 @@ export default function ChatRichTextEditor({
       }
     }
 
-    // Giphy detection — independent of mention/emoji triggers
+    // Giphy detection — only triggers when /giphy <query> is the entire message
+    const giphyMatch = newContent.match(/^\/giphy\s+(.+)/)
+    const giphyQuery = giphyMatch ? giphyMatch[1].trim() : ""
 
-    const giphyMatch = beforeCursor.match(/\/giphy\s+(\S+)$/)
-
-    if (giphyMatch) {
+    if (giphyQuery) {
       const rect = textarea.getBoundingClientRect()
 
       setGiphyState({
-        query: giphyMatch[1],
+        query: giphyQuery,
 
         anchor: { left: rect.left, top: rect.top, bottom: rect.bottom },
       })
@@ -540,48 +540,18 @@ export default function ChatRichTextEditor({
   }
 
   const handleGiphyInsert = (url: string) => {
-    const textarea = textareaRef.current
-
-    const cursor = textarea?.selectionStart ?? content.length
-
-    const beforeCursor = content.slice(0, cursor)
-
-    const afterCursor = content.slice(cursor)
-
-    const replaced = beforeCursor.replace(/\/giphy\s+\S+$/, url)
-
-    const newContent = replaced + afterCursor
-
-    onChange(newContent)
-
     setGiphyState(null)
 
-    requestAnimationFrame(() => {
-      textarea?.focus()
-
-      textarea?.setSelectionRange(replaced.length, replaced.length)
-    })
+    onSend(url)
   }
 
   const handleGiphyCancel = () => {
-    const textarea = textareaRef.current
-
-    const cursor = textarea?.selectionStart ?? content.length
-
-    const beforeCursor = content.slice(0, cursor)
-
-    const afterCursor = content.slice(cursor)
-
-    const replaced = beforeCursor.replace(/\/giphy\s+\S+$/, "")
-
-    onChange(replaced + afterCursor)
+    onChange("")
 
     setGiphyState(null)
 
     requestAnimationFrame(() => {
-      textarea?.focus()
-
-      textarea?.setSelectionRange(replaced.length, replaced.length)
+      textareaRef.current?.focus()
     })
   }
 
@@ -676,7 +646,7 @@ export default function ChatRichTextEditor({
     if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       event.preventDefault()
 
-      if (content.trim() || attachments.length > 0) {
+      if (!giphyState && (content.trim() || attachments.length > 0)) {
         onSend()
       }
 
@@ -690,7 +660,7 @@ export default function ChatRichTextEditor({
     if (event.key === "Enter" && !event.shiftKey && !isMobile) {
       event.preventDefault()
 
-      if (content.trim() || attachments.length > 0) {
+      if (!giphyState && (content.trim() || attachments.length > 0)) {
         onSend()
       }
     }
@@ -768,7 +738,7 @@ export default function ChatRichTextEditor({
         <GiphyPicker
           query={giphyState.query}
           anchor={giphyState.anchor}
-          onInsert={handleGiphyInsert}
+          onSend={handleGiphyInsert}
           onCancel={handleGiphyCancel}
         />
       )}
@@ -1053,7 +1023,7 @@ export default function ChatRichTextEditor({
           size={isMobile ? "md" : "lg"}
           radius="md"
           variant="filled"
-          onClick={onSend}
+          onClick={() => onSend()}
           disabled={disabled || isEmpty}
           mb={1}
           mr={isMobile ? 2 : undefined}

--- a/frontend/src/components/GiphyPicker.tsx
+++ b/frontend/src/components/GiphyPicker.tsx
@@ -28,7 +28,7 @@ interface GiphyPickerProps {
 
   anchor: GiphyAnchor
 
-  onInsert: (url: string) => void
+  onSend: (url: string) => void
 
   onCancel: () => void
 }
@@ -40,7 +40,7 @@ export default function GiphyPicker({
 
   anchor,
 
-  onInsert,
+  onSend,
 
   onCancel,
 }: GiphyPickerProps) {
@@ -145,8 +145,8 @@ export default function GiphyPicker({
             radius="sm"
           />
           <Group gap="xs">
-            <Button size="xs" onClick={() => onInsert(gif.originalUrl)}>
-              Indsæt
+            <Button size="xs" onClick={() => onSend(gif.originalUrl)}>
+              Send
             </Button>
             <Button size="xs" variant="default" onClick={() => doFetch(query)}>
               Ny GIF

--- a/frontend/src/components/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState, lazy, Suspense } from "react"
 
+import { flushSync } from "react-dom"
+
 import { useEditor } from "@tiptap/react"
 
 import { mergeAttributes, Extension } from "@tiptap/core"
@@ -55,14 +57,17 @@ function detectGiphy(editor: Editor, setter: (s: GiphyState | null) => void) {
 
   const { from } = editor.state.selection
 
-  const text = editor.state.doc.textBetween(0, from, "\n")
+  // Only trigger when /giphy <query> is the entire document content
+  const fullText = editor.state.doc.textContent
 
-  const match = text.match(/\/giphy\s+(\S+)$/)
+  const match = fullText.match(/^\/giphy\s+(.+)/)
 
-  if (match) {
+  const query = match ? match[1].trim() : ""
+
+  if (query) {
     const coords = editor.view.coordsAtPos(from)
 
-    setter({ query: match[1], anchor: coords, from })
+    setter({ query, anchor: coords, from })
   } else {
     setter(null)
   }
@@ -415,43 +420,21 @@ export default function RichTextEditor({
   }, [])
 
   const handleGiphyInsert = (url: string) => {
-    if (!giphyState || !editor) return
+    if (!editor) return
 
-    const { query, from } = giphyState
+    editor.chain().focus().clearContent().setImage({ src: url }).run()
 
-    const triggerLen = "/giphy ".length + query.length
+    flushSync(() => {
+      setGiphyState(null)
+    })
 
-    editor
-
-      .chain()
-
-      .focus()
-
-      .deleteRange({ from: from - triggerLen, to: from })
-
-      .setImage({ src: url })
-
-      .run()
-
-    setGiphyState(null)
+    onSubmitRef.current?.()
   }
 
   const handleGiphyCancel = () => {
-    if (!giphyState || !editor) return
+    if (!editor) return
 
-    const { query, from } = giphyState
-
-    const triggerLen = "/giphy ".length + query.length
-
-    editor
-
-      .chain()
-
-      .focus()
-
-      .deleteRange({ from: from - triggerLen, to: from })
-
-      .run()
+    editor.chain().focus().clearContent().run()
 
     setGiphyState(null)
   }
@@ -474,7 +457,7 @@ export default function RichTextEditor({
         <GiphyPicker
           query={giphyState.query}
           anchor={giphyState.anchor}
-          onInsert={handleGiphyInsert}
+          onSend={handleGiphyInsert}
           onCancel={handleGiphyCancel}
         />
       )}

--- a/frontend/src/pages/MessagesPage.tsx
+++ b/frontend/src/pages/MessagesPage.tsx
@@ -1280,18 +1280,20 @@ function ChatArea({
     }
   }, [conversation.id, conversation.messages, location.hash])
 
-  const handleSend = async () => {
-    const textContent = message.trim()
+  const handleSend = async (contentOverride?: string) => {
+    const messageContent =
+      contentOverride !== undefined ? contentOverride : message
+
+    const textContent = messageContent.trim()
 
     if ((!textContent && attachments.length === 0) || isSending) return
 
     setIsSending(true)
 
-    const messageContent = message
-
     const messageAttachments = [...attachments]
 
-    const messageMentions = [...mentionedUserIds]
+    const messageMentions =
+      contentOverride !== undefined ? [] : [...mentionedUserIds]
 
     setMessage("") // Clear immediately for better UX
 
@@ -2629,13 +2631,16 @@ function NewConversationArea({ onBack, onSuccess }: NewConversationAreaProps) {
     setSelectedUsers((prev) => prev.filter((u) => u.id !== userId))
   }
 
-  const handleSend = async () => {
+  const handleSend = async (contentOverride?: string) => {
     if (selectedUsers.length === 0) return
+
+    const messageContent =
+      contentOverride !== undefined ? contentOverride : message
 
     createMutation.mutate({
       participant_ids: selectedUsers.map((u) => u.id),
 
-      initial_message: message.trim() || undefined,
+      initial_message: messageContent.trim() || undefined,
 
       attachments: attachments.length > 0 ? attachments : undefined,
     })


### PR DESCRIPTION
Cleans up the giphy integration. It is now more similar to the implementation on Slack:
- Only works of the input starts with /giphy (it's a block command, not inline)
- Sends the selected gif from the prompt instead of putting it into the text editor filed
- Works the same on forums as in DM's