### PR TITLE
Gate /media behind login (Django session cookie)

### DIFF
--- a/backend/apps/backup/tests.py
+++ b/backend/apps/backup/tests.py
@@ -195,6 +195,37 @@ class ServeMediaAuthTest(TestCase):
             response = client.get(f"/media/{self.file_path}")
         assert response.status_code == 200
 
+    def test_jwt_refresh_backfills_session(self):
+        """Silent token refresh (used when an access token expires) must also
+        set the session cookie. Otherwise, returning users would 401 on
+        `/media/*` until their first API call backfilled a session — causing a
+        one-time flash of broken images on first load post-deploy.
+        """
+        client = Client()
+        # First login to get a refresh token.
+        login = client.post(
+            "/api/auth/token/",
+            data={"email": "media-auth@example.com", "password": "testpass123"},
+            content_type="application/json",
+        )
+        refresh_token = login.json()["refresh"]
+
+        # Simulate a fresh client (no session yet) calling /token/refresh/.
+        client.cookies.clear()
+        refresh = client.post(
+            "/api/auth/token/refresh/",
+            data={"refresh": refresh_token},
+            content_type="application/json",
+        )
+        assert refresh.status_code == 200
+        assert "sessionid" in refresh.cookies, (
+            "Refresh must set a sessionid cookie so /media/* is accessible immediately."
+        )
+
+        with override_settings(MEDIA_ROOT=str(self.media_root)):
+            response = client.get(f"/media/{self.file_path}")
+        assert response.status_code == 200
+
     def test_logout_revokes_media_access(self):
         client = Client()
         client.force_login(self.user)

--- a/backend/apps/backup/tests.py
+++ b/backend/apps/backup/tests.py
@@ -2,17 +2,20 @@
 Tests for the backup app.
 """
 
+import tempfile
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from django.apps import apps as django_apps
 from django.db.models.signals import post_delete, post_save, pre_save
-from django.test import TestCase, override_settings
+from django.test import Client, TestCase, override_settings
 
 from apps.backup.s3 import is_enabled
 from apps.backup.signals import ATTACHMENT_MODELS, IMAGE_MODELS
 from apps.backup.tasks import _check_litestream_health
 from apps.backup.views import _is_safe_path
+from apps.users.models import User
 
 
 class SignalRegistrationTest(TestCase):
@@ -132,3 +135,82 @@ class CheckLitestreamHealthTest(TestCase):
         # ever touching S3.
         _check_litestream_health()
         mock_get_client.assert_not_called()
+
+
+class ServeMediaAuthTest(TestCase):
+    """`/media/*` must require an authenticated session.
+
+    Regression: media files (profile pictures, post/message attachments) used
+    to be publicly fetchable by guessing the URL. The fix gates `serve_media`
+    on `request.user.is_authenticated`, with the session set as a side-effect
+    of the JWT login flow.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.media_root = Path(self.tmpdir)
+        (self.media_root / "post_attachments").mkdir()
+        self.file_path = "post_attachments/test.txt"
+        (self.media_root / self.file_path).write_text("secret payload")
+
+        self.user = User.objects.create_user(
+            email="media-auth@example.com",
+            password="testpass123",
+            first_name="Media",
+            last_name="Tester",
+        )
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_unauthenticated_request_returns_401(self):
+        with override_settings(MEDIA_ROOT=str(self.media_root)):
+            response = Client().get(f"/media/{self.file_path}")
+        assert response.status_code == 401
+
+    def test_authenticated_session_can_fetch(self):
+        client = Client()
+        client.force_login(self.user)
+        with override_settings(MEDIA_ROOT=str(self.media_root)):
+            response = client.get(f"/media/{self.file_path}")
+        assert response.status_code == 200
+        assert b"secret payload" in b"".join(response.streaming_content)
+
+    def test_jwt_login_grants_media_access(self):
+        """Logging in via the JWT endpoint must set the session cookie that
+        gates media."""
+        client = Client()
+        login_response = client.post(
+            "/api/auth/token/",
+            data={"email": "media-auth@example.com", "password": "testpass123"},
+            content_type="application/json",
+        )
+        assert login_response.status_code == 200
+        # The session cookie was set as a side-effect of login.
+        assert "sessionid" in login_response.cookies
+
+        with override_settings(MEDIA_ROOT=str(self.media_root)):
+            response = client.get(f"/media/{self.file_path}")
+        assert response.status_code == 200
+
+    def test_logout_revokes_media_access(self):
+        client = Client()
+        client.force_login(self.user)
+        with override_settings(MEDIA_ROOT=str(self.media_root)):
+            # Sanity: logged in, media works.
+            assert client.get(f"/media/{self.file_path}").status_code == 200
+
+            logout_response = client.post("/api/auth/logout/")
+            assert logout_response.status_code == 204
+
+            assert client.get(f"/media/{self.file_path}").status_code == 401
+
+    def test_scanner_path_still_404s_without_auth(self):
+        # Scanner traps should short-circuit before the auth check so we don't
+        # leak that the path exists/doesn't exist behind a 401 vs 404 split.
+        # Either 401 or 404 is acceptable; we just want it not to serve content.
+        with override_settings(MEDIA_ROOT=str(self.media_root)):
+            response = Client().get("/media/.env")
+        assert response.status_code in (401, 404)

--- a/backend/apps/backup/views.py
+++ b/backend/apps/backup/views.py
@@ -50,6 +50,12 @@ def serve_media(request: HttpRequest, path: str) -> HttpResponse:
     if _is_scanner_path(path):
         raise Http404
 
+    # /media is gated by the same Django session that the JWT login flow
+    # creates. Same-origin <img src="/media/..."> tags carry the sessionid
+    # cookie automatically, so no client-side change is needed.
+    if not request.user.is_authenticated:
+        return HttpResponse(status=401)
+
     local_path = Path(settings.MEDIA_ROOT) / path
     if not local_path.is_file():
         from apps.backup.s3 import download_file, is_enabled

--- a/backend/apps/users/authentication.py
+++ b/backend/apps/users/authentication.py
@@ -1,0 +1,31 @@
+"""
+JWT authentication that also issues a Django session cookie.
+
+The session cookie gates same-origin `/media/*` requests so `<img src="/media/...">`
+tags carry credentials automatically. JWT remains the primary auth for the API;
+the session is purely a side-effect to make file URLs authenticated.
+"""
+
+from django.contrib import auth
+from rest_framework.request import Request
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+
+class JWTSessionAuthentication(JWTAuthentication):
+    """JWT auth that ensures a Django session exists for the authenticated user.
+
+    On a successful JWT auth, if the request has no session yet, log the user
+    in via `django.contrib.auth.login` so SessionMiddleware sets a sessionid
+    cookie on the response. Subsequent same-origin requests (including
+    `<img>` fetches of `/media/...`) then carry the cookie automatically.
+    """
+
+    def authenticate(self, request: Request) -> tuple | None:
+        result = super().authenticate(request)
+        if result is None:
+            return None
+
+        user, _ = result
+        if not request.session.session_key:
+            auth.login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+        return result

--- a/backend/apps/users/urls.py
+++ b/backend/apps/users/urls.py
@@ -13,6 +13,7 @@ from .views import (
     DownloadMediaView,
     ForgotPasswordView,
     InvitationListCreateView,
+    LogoutView,
     RegisterView,
     RequestEmailChangeView,
     ResetPasswordView,
@@ -21,6 +22,7 @@ from .views import (
 
 urlpatterns = [
     path("register/", RegisterView.as_view(), name="register"),
+    path("logout/", LogoutView.as_view(), name="logout"),
     path("validate-invitation/", ValidateInvitationView.as_view(), name="validate-invitation"),
     path("invitations/", InvitationListCreateView.as_view(), name="invitations"),
     path("change-password/", ChangePasswordView.as_view(), name="change-password"),

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -11,6 +11,7 @@ import tempfile
 from typing import Any
 
 from django.conf import settings
+from django.contrib import auth
 from django.db import connection, models
 from django.db.models import Count, QuerySet
 from django.http import FileResponse, HttpResponse
@@ -274,6 +275,27 @@ class ResetPasswordView(APIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response({"message": "Password has been reset successfully."})
+
+
+class LogoutView(APIView):
+    """
+    Destroy the Django session that gates /media/* access.
+
+    JWT-side logout is purely client (the frontend drops the access/refresh
+    tokens from localStorage). This endpoint flushes the server-side session so
+    the sessionid cookie can no longer be used to fetch media after logout.
+
+    `authentication_classes = []` and AllowAny so a user with an
+    expired/malformed JWT can still successfully log out — the session is
+    identified by the cookie, not the JWT.
+    """
+
+    authentication_classes: list = []
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request: Request) -> Response:
+        auth.logout(request)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class RequestEmailChangeView(APIView):

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -170,7 +170,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # REST Framework settings
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "apps.users.authentication.JWTSessionAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
@@ -234,6 +234,13 @@ STORAGES = {
 # Media files (uploads)
 MEDIA_URL = "media/"
 MEDIA_ROOT = DATA_DIR / "media"
+
+# Session cookie used to gate /media/* requests. JWT remains the primary auth
+# for the API; the session is set as a side-effect of the JWT login flow so
+# same-origin <img src="/media/..."> tags carry credentials automatically.
+SESSION_COOKIE_AGE = 60 * 60 * 24 * 30  # 30 days
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = "Lax"
 
 # S3 backup storage (set S3_BACKUP_BUCKET to enable; empty = disabled)
 # Used for media file sync (via Django signals) and Litestream continuous DB replication.

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -2,10 +2,16 @@
 URL configuration for KB Intra project.
 """
 
-from django.contrib import admin
+from typing import Any
+
+from django.contrib import admin, auth
 from django.http import HttpRequest, JsonResponse
 from django.urls import include, path, re_path
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from apps.backup.views import serve_media
@@ -14,6 +20,20 @@ from apps.backup.views import serve_media
 class ThrottledTokenObtainPairView(TokenObtainPairView):
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = "login"
+
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # Replicates the parent post(), but additionally calls auth.login() so
+        # the response carries a sessionid cookie. The session gates same-origin
+        # /media/* requests (gives <img src="/media/..."> credentials for free).
+        serializer = self.get_serializer(data=request.data)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except TokenError as e:
+            raise InvalidToken(e.args[0]) from e
+
+        auth.login(request, serializer.user, backend="django.contrib.auth.backends.ModelBackend")
+
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)
 
 
 def health_check(request: HttpRequest) -> JsonResponse:

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -12,9 +12,12 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from rest_framework_simplejwt.tokens import AccessToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from apps.backup.views import serve_media
+
+_AUTH_BACKEND = "django.contrib.auth.backends.ModelBackend"
 
 
 class ThrottledTokenObtainPairView(TokenObtainPairView):
@@ -31,9 +34,42 @@ class ThrottledTokenObtainPairView(TokenObtainPairView):
         except TokenError as e:
             raise InvalidToken(e.args[0]) from e
 
-        auth.login(request, serializer.user, backend="django.contrib.auth.backends.ModelBackend")
+        auth.login(request, serializer.user, backend=_AUTH_BACKEND)
 
         return Response(serializer.validated_data, status=status.HTTP_200_OK)
+
+
+class TokenRefreshWithSessionView(TokenRefreshView):
+    """`TokenRefreshView` that also (re)issues the Django session cookie.
+
+    Why: JWT silent-refresh runs without going through `JWTSessionAuthentication`
+    (the refresh token is in the body, not the Bearer header). Without this,
+    returning users whose access token expired between visits would 401 on
+    `/media/*` until their first authenticated API call backfills a session —
+    causing a one-time flash of broken images on first page load.
+    """
+
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        response = super().post(request, *args, **kwargs)
+        if response.status_code != 200:
+            return response
+
+        # Decode the just-issued access token to find the user. The token is
+        # signed and was produced by trusted code, so this is safe.
+        try:
+            access = AccessToken(response.data["access"])
+            from apps.users.models import User  # avoid circular import at module load
+
+            user = User.objects.get(pk=access["user_id"], is_active=True)
+        except Exception:
+            # Refresh succeeded — don't break the response if the session
+            # bridge can't find the user (deleted, deactivated, etc.). JWT auth
+            # still works; `JWTSessionAuthentication` will create the session
+            # on the next API call.
+            return response
+
+        auth.login(request, user, backend=_AUTH_BACKEND)
+        return response
 
 
 def health_check(request: HttpRequest) -> JsonResponse:
@@ -51,7 +87,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     # JWT Authentication
     path("api/auth/token/", ThrottledTokenObtainPairView.as_view(), name="token_obtain_pair"),
-    path("api/auth/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("api/auth/token/refresh/", TokenRefreshWithSessionView.as_view(), name="token_refresh"),
     # App APIs
     path("api/auth/", include("apps.users.urls")),
     path("api/users/", include("apps.users.urls_users")),

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -208,9 +208,10 @@ describe("authApi", () => {
   })
 
   describe("logout", () => {
-    it("should clear tokens on logout", () => {
+    it("should clear tokens and hit the server logout endpoint", () => {
       authApi.logout()
 
+      expect(apiClient.post).toHaveBeenCalledWith("/auth/logout/")
       expect(clearTokens).toHaveBeenCalled()
     })
   })

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -84,6 +84,13 @@ export const authApi = {
   },
 
   logout(): void {
+    // Fire-and-forget: the server destroys the Django session that gates
+    // /media/* access. We don't await — clearing local tokens shouldn't
+    // depend on the server round-trip. Wrapping with Promise.resolve()
+    // tolerates mocks that return undefined synchronously in tests.
+    Promise.resolve(apiClient.post("/auth/logout/")).catch(() => {
+      // Best-effort; session expires server-side after 30 days anyway.
+    })
     clearTokens()
   },
 


### PR DESCRIPTION
## Summary
- `/media/*` was publicly fetchable — anyone who guessed a profile-picture filename or message-attachment URL could download it without logging in. Reported in [this forum thread](https://kb-intra.dk/forum/bugs/traad/kan-alle-stadig-downloade-alle-filer-hvis-de-kan-gætte-urlen).
- Gate `/media/*` behind a Django session cookie, issued as a side-effect of the JWT login flow. JWT remains the primary auth for the API; the session is purely so same-origin `<img src="/media/...">` tags carry credentials automatically.
- Three places set the cookie: `POST /api/auth/token/` (login), `POST /api/auth/token/refresh/` (silent renewal — prevents broken-image flash for returning users), and a `JWTSessionAuthentication` class that backfills a session on the first API call for any JWT-authenticated user without one (so existing logged-in users don't get forced to re-login post-deploy).
- New `POST /api/auth/logout/` endpoint that destroys the session.

## What it covers
All in-app file surfaces:
- `/media/profile_pictures/`, `/media/house_pictures/`, `/media/child_pictures/`
- `/media/post_attachments/`, `/media/forum_files/`, `/media/announcement_attachments/`
- `/media/message_attachments/` (most sensitive — was sitting publicly)
- `/media/rooms/`

Other file-serving endpoints (`/api/forum/folders/<id>/download/`, `/api/auth/admin/download-db/`, `/api/auth/me/export/`, etc.) were already authenticated.

## Test plan
- [x] `pytest` — 639/639 pass (5 new in `apps/backup/tests.py::ServeMediaAuthTest`: unauthenticated 401, authenticated 200, JWT login sets cookie, JWT refresh sets cookie, logout revokes access)
- [x] `vitest` — 386/386 pass
- [x] `ruff check`, `ruff format`, `oxlint`, `oxfmt`, `tsgo`, `ty` — all clean
- [x] Browser smoke-tested end-to-end: login, refresh, logout, and 13 adjacent pages (forum threads with attachments, beboeroversigt with 207 profile pics, messages, announcements). Zero broken images, zero console errors.
- [x] Verified the migration path: existing JWT in localStorage with no session cookie → first API call quietly backfills the session → no forced re-login.

## Deploy notes
- Old emails with inline `<img src="https://kb-intra.dk/media/...">` will show broken previews in mail clients (cookies don't flow there). Acceptable for a ~90-user community; users click through to the app to view.
- Push notification icons use the static `/pwa-192x192.png` (services.py:254), not `/media`, so push is unaffected.
- The R2 backup bucket is already private — there's no side channel.
- Rollback is safe: if reverted, sessionid cookies become unused but cause no errors. DB schema unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)