### PR TITLE
Mark /media responses private so Cloudflare won't cache them

### DIFF
--- a/backend/apps/backup/tests.py
+++ b/backend/apps/backup/tests.py
@@ -245,3 +245,29 @@ class ServeMediaAuthTest(TestCase):
         with override_settings(MEDIA_ROOT=str(self.media_root)):
             response = Client().get("/media/.env")
         assert response.status_code in (401, 404)
+
+    def test_cache_control_prevents_cdn_caching(self):
+        """Cloudflare (and any shared cache) must not cache `/media/*` responses.
+
+        Without `Cache-Control: private`, the first authenticated user's 200
+        gets cached at the CDN and subsequent unauthenticated users would
+        receive the same file — bypassing the auth gate entirely.
+        """
+        client = Client()
+        client.force_login(self.user)
+        with override_settings(MEDIA_ROOT=str(self.media_root)):
+            response = client.get(f"/media/{self.file_path}")
+        assert response.status_code == 200
+        cache_control = response["Cache-Control"].lower()
+        assert "private" in cache_control, (
+            f"200 must be Cache-Control: private. Got {cache_control!r}"
+        )
+
+        # The 401 must also be uncacheable, otherwise a stale 401 could be
+        # served from the CDN to authenticated users.
+        anon_response = Client().get(f"/media/{self.file_path}")
+        assert anon_response.status_code == 401
+        anon_cc = anon_response["Cache-Control"].lower()
+        assert "private" in anon_cc and "no-store" in anon_cc, (
+            f"401 must be Cache-Control: private, no-store. Got {anon_cc!r}"
+        )

--- a/backend/apps/backup/views.py
+++ b/backend/apps/backup/views.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from django.conf import settings
 from django.http import Http404, HttpRequest, HttpResponse
+from django.utils.cache import patch_cache_control
 from django.views.static import serve
 
 
@@ -54,7 +55,12 @@ def serve_media(request: HttpRequest, path: str) -> HttpResponse:
     # creates. Same-origin <img src="/media/..."> tags carry the sessionid
     # cookie automatically, so no client-side change is needed.
     if not request.user.is_authenticated:
-        return HttpResponse(status=401)
+        # `no-store` so Cloudflare (or any shared cache) doesn't memoize the
+        # 401 for a URL — otherwise a later authenticated user would still see
+        # 401 from cache.
+        response = HttpResponse(status=401)
+        response["Cache-Control"] = "private, no-store"
+        return response
 
     local_path = Path(settings.MEDIA_ROOT) / path
     if not local_path.is_file():
@@ -67,4 +73,9 @@ def serve_media(request: HttpRequest, path: str) -> HttpResponse:
         else:
             raise Http404
 
-    return serve(request, path, document_root=settings.MEDIA_ROOT)
+    response = serve(request, path, document_root=settings.MEDIA_ROOT)
+    # `private` keeps Cloudflare/any shared cache from storing the file (it's
+    # per-user, not per-URL). The browser may still cache it for max_age seconds
+    # — that's a per-user cache so no leak between users.
+    patch_cache_control(response, private=True, max_age=3600)
+    return response


### PR DESCRIPTION
## Summary
Follow-up to PR #82. After the media auth gate deployed, Cloudflare was still serving cached files to unauthenticated visitors — `cf-cache-status: HIT` was returning 200s without ever reaching the origin. Even after a one-time CDN purge, the same problem would re-occur: the first authenticated user's 200 gets cached at the CDN and then served to subsequent anonymous visitors, bypassing the auth gate entirely.

Set `Cache-Control: private` on `/media/*` responses:
- **200**: `private, max-age=3600` — browser may cache per-user (no cross-user leak); Cloudflare won't.
- **401**: `private, no-store` — stale 401s mustn't get pinned at the CDN either.

## Deploy steps
1. Merge this PR.
2. Purge Cloudflare's existing `/media/*` cache (Caching → Configuration → Custom Purge → `https://kb-intra.dk/media/*`, or Purge Everything).
3. Verify: `curl -I https://kb-intra.dk/media/profile_pictures/cmkobel.jpg` should return `401` with `cache-control: private, no-store` and `cf-cache-status: BYPASS` or `DYNAMIC`.

## Test plan
- [x] `pytest apps/backup/tests.py::ServeMediaAuthTest` — 7/7 pass (1 new: `test_cache_control_prevents_cdn_caching`)
- [x] Full `pytest` — 640/640 pass
- [x] `ruff check`, `ruff format` — clean
- [x] Live curl against the local backend: 401 has `Cache-Control: private, no-store`, 200 has `Cache-Control: private, max-age=3600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)