### PR TITLE
Add Galleri tab to forum subgroups

### DIFF
--- a/backend/apps/forum/serializers.py
+++ b/backend/apps/forum/serializers.py
@@ -53,6 +53,37 @@ class PostAttachmentSerializer(serializers.ModelSerializer):
         return ""
 
 
+class GalleryItemSerializer(serializers.ModelSerializer):
+    """A PostAttachment paired with its parent thread, for the subgroup gallery."""
+
+    uploaded_by = AuthorSerializer(read_only=True)
+    file_url = serializers.SerializerMethodField()
+    thread_id = serializers.IntegerField(source="post.thread.id", read_only=True)
+    thread_slug = serializers.CharField(source="post.thread.slug", read_only=True)
+    thread_title = serializers.CharField(source="post.thread.title", read_only=True)
+    subgroup_slug = serializers.CharField(source="post.thread.subgroup.slug", read_only=True)
+
+    class Meta:
+        model = PostAttachment
+        fields = [
+            "id",
+            "name",
+            "file_url",
+            "preview_html",
+            "uploaded_at",
+            "uploaded_by",
+            "thread_id",
+            "thread_slug",
+            "thread_title",
+            "subgroup_slug",
+        ]
+
+    def get_file_url(self, obj: PostAttachment) -> str:
+        if obj.file:
+            return obj.file.url
+        return ""
+
+
 class SubgroupMembershipSerializer(serializers.ModelSerializer):
     """Serializer for a single membership row (used inside subgroup detail)."""
 

--- a/backend/apps/forum/tests.py
+++ b/backend/apps/forum/tests.py
@@ -2230,3 +2230,108 @@ class TestCreatePrivateThreadValidation:
             format="json",
         )
         assert response.status_code == 400
+
+
+class TestSubgroupGallery:
+    """Tests for the subgroup gallery endpoint."""
+
+    def _make_attachment(self, db, user, thread, name, content=b"x"):
+        from apps.forum.models import PostAttachment
+
+        post = Post.objects.create(thread=thread, author=user, content="<p>see</p>")
+        return PostAttachment.objects.create(
+            post=post,
+            uploaded_by=user,
+            file=SimpleUploadedFile(name, content),
+            name=name,
+        )
+
+    def test_lists_attachments_in_subgroup_newest_first(
+        self, authenticated_client, db, user, subgroup, thread
+    ):
+        a1 = self._make_attachment(db, user, thread, "first.jpg")
+        a2 = self._make_attachment(db, user, thread, "second.pdf")
+        a3 = self._make_attachment(db, user, thread, "third.png")
+
+        response = authenticated_client.get(f"/api/forum/subgroups/{subgroup.slug}/gallery/")
+        assert response.status_code == 200
+        results = get_results(response.data)
+        ids = [item["id"] for item in results]
+        assert ids == [a3.id, a2.id, a1.id]
+        first = results[0]
+        assert first["name"] == "third.png"
+        assert first["thread_id"] == thread.id
+        assert first["thread_slug"] == thread.slug
+        assert first["thread_title"] == thread.title
+        assert first["subgroup_slug"] == subgroup.slug
+
+    def test_only_returns_attachments_for_the_requested_subgroup(
+        self, authenticated_client, db, user, subgroup
+    ):
+        other = Subgroup.objects.create(name="Other", slug="other")
+        t1 = Thread.objects.create(subgroup=subgroup, title="A", author=user)
+        t2 = Thread.objects.create(subgroup=other, title="B", author=user)
+        self._make_attachment(db, user, t1, "in-subgroup.png")
+        self._make_attachment(db, user, t2, "in-other.png")
+
+        response = authenticated_client.get(f"/api/forum/subgroups/{subgroup.slug}/gallery/")
+        names = [item["name"] for item in get_results(response.data)]
+        assert names == ["in-subgroup.png"]
+
+    def test_hides_attachments_from_members_only_threads_for_non_members(
+        self, second_authenticated_client, user, member_subgroup
+    ):
+        # Public thread + attachment.
+        public_thread = Thread.objects.create(subgroup=member_subgroup, title="Public", author=user)
+        self._make_attachment(None, user, public_thread, "public.png")
+
+        # Members-only thread + attachment.
+        private_thread = Thread.objects.create(
+            subgroup=member_subgroup,
+            title="Private",
+            author=user,
+            members_only=True,
+        )
+        self._make_attachment(None, user, private_thread, "private.png")
+
+        response = second_authenticated_client.get(
+            f"/api/forum/subgroups/{member_subgroup.slug}/gallery/"
+        )
+        names = [item["name"] for item in get_results(response.data)]
+        assert names == ["public.png"]
+
+    def test_members_see_attachments_from_members_only_threads(
+        self, member_client, user, member_subgroup
+    ):
+        private_thread = Thread.objects.create(
+            subgroup=member_subgroup,
+            title="Private",
+            author=user,
+            members_only=True,
+        )
+        self._make_attachment(None, user, private_thread, "secret.png")
+
+        response = member_client.get(f"/api/forum/subgroups/{member_subgroup.slug}/gallery/")
+        names = [item["name"] for item in get_results(response.data)]
+        assert names == ["secret.png"]
+
+    def test_404_for_unknown_subgroup(self, authenticated_client):
+        response = authenticated_client.get("/api/forum/subgroups/does-not-exist/gallery/")
+        assert response.status_code == 404
+
+    def test_requires_auth(self, api_client, subgroup):
+        response = api_client.get(f"/api/forum/subgroups/{subgroup.slug}/gallery/")
+        assert response.status_code in (401, 403)
+
+    def test_paginates_with_page_param(self, authenticated_client, db, user, subgroup, thread):
+        for i in range(5):
+            self._make_attachment(db, user, thread, f"f{i}.png")
+
+        response = authenticated_client.get(
+            f"/api/forum/subgroups/{subgroup.slug}/gallery/?page_size=2"
+        )
+        assert response.status_code == 200
+        assert "results" in response.data
+        assert len(response.data["results"]) == 2
+        assert response.data["count"] == 5
+        assert response.data["next"] is not None

--- a/backend/apps/forum/urls.py
+++ b/backend/apps/forum/urls.py
@@ -27,6 +27,7 @@ from .views import (
     RecentActivityView,
     SubgroupDetailView,
     SubgroupFileListCreateView,
+    SubgroupGalleryView,
     SubgroupLeaveView,
     SubgroupListView,
     SubgroupMemberDetailView,
@@ -86,6 +87,12 @@ urlpatterns = [
         name="mark-subgroup-read",
     ),
     path("subscriptions/", MySubscriptionsView.as_view(), name="my-subscriptions"),
+    # Gallery
+    path(
+        "subgroups/<slug:slug>/gallery/",
+        SubgroupGalleryView.as_view(),
+        name="subgroup-gallery",
+    ),
     # Threads
     path("subgroups/<slug:slug>/threads/", ThreadListCreateView.as_view(), name="thread-list"),
     path(

--- a/backend/apps/forum/views.py
+++ b/backend/apps/forum/views.py
@@ -23,6 +23,7 @@ from .models import (
     PollOption,
     PollVote,
     Post,
+    PostAttachment,
     Reaction,
     Subgroup,
     SubgroupMembership,
@@ -38,6 +39,7 @@ from .serializers import (
     FileUploadSerializer,
     FolderCreateSerializer,
     FolderSerializer,
+    GalleryItemSerializer,
     PollSerializer,
     PollUpdateSerializer,
     PostCreateSerializer,
@@ -519,6 +521,48 @@ class ThreadPagination(PageNumberPagination):
     page_size = 20
     page_size_query_param = "page_size"
     max_page_size = 100
+
+
+class GalleryPagination(PageNumberPagination):
+    page_size = 60
+    page_size_query_param = "page_size"
+    max_page_size = 200
+
+
+class SubgroupGalleryView(generics.ListAPIView):
+    """All post attachments in a subgroup's threads, newest first.
+
+    Respects thread members_only visibility — attachments from member-only
+    threads are hidden unless the requester is a member of the subgroup or
+    authored the parent thread.
+    """
+
+    serializer_class = GalleryItemSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    pagination_class = GalleryPagination
+
+    def get_queryset(self) -> Any:
+        subgroup = get_object_or_404(Subgroup, slug=self.kwargs["slug"])
+        user = self.request.user
+
+        visible = Q(post__thread__members_only=False)
+        if user.is_authenticated:
+            member_ids = list(
+                SubgroupMembership.objects.filter(user=user).values_list("subgroup_id", flat=True)
+            )
+            visible = (
+                visible | Q(post__thread__subgroup_id__in=member_ids) | Q(post__thread__author=user)
+            )
+
+        return (
+            PostAttachment.objects.filter(post__thread__subgroup=subgroup)
+            .filter(visible)
+            .select_related(
+                "uploaded_by",
+                "post__thread__subgroup",
+            )
+            .order_by("-uploaded_at", "-id")
+        )
 
 
 class ThreadListCreateView(generics.ListCreateAPIView):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -408,6 +408,16 @@ const AuthenticatedRoutes = memo(function AuthenticatedRoutes() {
           }
         />
         <Route
+          path="/forum/:slug/galleri"
+          element={
+            <ProtectedRoute>
+              <ErrorBoundary>
+                <SubgroupPage />
+              </ErrorBoundary>
+            </ProtectedRoute>
+          }
+        />
+        <Route
           path="/forum/:slug"
           element={
             <ProtectedRoute>

--- a/frontend/src/api/forum.ts
+++ b/frontend/src/api/forum.ts
@@ -20,6 +20,7 @@ import type {
   Poll,
   Folder,
   ForumFile,
+  GalleryItem,
   RecentActivity,
   ReactionType,
   ReactionTypeInfo,
@@ -29,6 +30,11 @@ export interface GetThreadsOptions {
   page?: number
   pageSize?: number
   isClosed?: boolean
+}
+
+export interface GetGalleryOptions {
+  page?: number
+  pageSize?: number
 }
 
 export interface FolderDeletePreview {
@@ -184,6 +190,21 @@ export const forumApi = {
     const response = await apiClient.get("/forum/subscriptions/")
 
     return asArray(response.data)
+  },
+
+  // Gallery
+  getSubgroupGallery: async (
+    subgroupSlug: string,
+    options: GetGalleryOptions = {},
+  ): Promise<PaginatedResponse<GalleryItem>> => {
+    const params: Record<string, string | number> = {}
+    if (options.page) params.page = options.page
+    if (options.pageSize) params.page_size = options.pageSize
+    const response = await apiClient.get<PaginatedResponse<GalleryItem>>(
+      `/forum/subgroups/${subgroupSlug}/gallery/`,
+      { params },
+    )
+    return response.data
   },
 
   // Threads

--- a/frontend/src/components/GalleryTab.tsx
+++ b/frontend/src/components/GalleryTab.tsx
@@ -1,0 +1,259 @@
+import { useState, useEffect, useRef, useMemo } from "react"
+
+import { Link } from "react-router-dom"
+
+import { useInfiniteQuery } from "@tanstack/react-query"
+
+import {
+  Stack,
+  SimpleGrid,
+  Box,
+  Image,
+  Text,
+  Anchor,
+  Alert,
+  Center,
+  Loader,
+  Paper,
+  ThemeIcon,
+} from "@mantine/core"
+
+import { IconInfoCircle, IconPhoto } from "@tabler/icons-react"
+
+import { forumApi } from "../api/forum"
+
+import { AttachmentCarousel } from "./AttachmentCarousel"
+
+import { getFileType, getFileIcon, getFileTypeColor } from "./FilePreview"
+
+import type { GalleryItem } from "../types"
+
+const PAGE_SIZE = 60
+
+interface GalleryTabProps {
+  subgroupSlug: string
+}
+
+export default function GalleryTab({ subgroupSlug }: GalleryTabProps) {
+  const {
+    data,
+    isLoading,
+    isError,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["subgroup-gallery", subgroupSlug],
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
+      forumApi.getSubgroupGallery(subgroupSlug, {
+        page: pageParam as number,
+        pageSize: PAGE_SIZE,
+      }),
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.next ? allPages.length + 1 : undefined,
+  })
+
+  const items: GalleryItem[] = useMemo(
+    () => data?.pages.flatMap((page) => page.results) ?? [],
+    [data],
+  )
+
+  // Infinite scroll: load more when sentinel enters view.
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el || !hasNextPage || isFetchingNextPage) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          void fetchNextPage()
+        }
+      },
+      { rootMargin: "400px" },
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  // Carousel state: which image to open, drawn from the gallery item list.
+  const [carouselOpen, setCarouselOpen] = useState(false)
+  const [carouselIndex, setCarouselIndex] = useState(0)
+
+  const imageItems = useMemo(
+    () => items.filter((item) => getFileType(item.name) === "image"),
+    [items],
+  )
+
+  const handleImageClick = (item: GalleryItem) => {
+    const idx = imageItems.findIndex((i) => i.id === item.id)
+    setCarouselIndex(idx >= 0 ? idx : 0)
+    setCarouselOpen(true)
+  }
+
+  const handleDocClick = (item: GalleryItem) => {
+    window.open(item.file_url, "_blank", "noopener,noreferrer")
+  }
+
+  const carouselAttachments = useMemo(
+    () =>
+      imageItems.map((item) => ({
+        id: item.id,
+        name: item.name,
+        file_url: item.file_url,
+        preview_html: item.preview_html,
+      })),
+    [imageItems],
+  )
+
+  return (
+    <Stack gap="md">
+      <Alert
+        icon={<IconInfoCircle size={16} />}
+        color="gray"
+        variant="light"
+        radius="md"
+      >
+        Vil du tilføje medie til galleriet? Vedhæft filer, billeder eller
+        dokumenter i en tråd — de dukker automatisk op her.
+      </Alert>
+
+      {isLoading && (
+        <Center h={120}>
+          <Loader />
+        </Center>
+      )}
+
+      {isError && (
+        <Text c="red">Kunne ikke indlæse galleriet. Prøv igen senere.</Text>
+      )}
+
+      {!isLoading && !isError && items.length === 0 && (
+        <Paper withBorder p="xl" radius="md">
+          <Stack align="center" gap="xs">
+            <IconPhoto size={32} color="var(--mantine-color-gray-5)" />
+            <Text c="dimmed">Ingen medier endnu.</Text>
+            <Text c="dimmed" size="sm" ta="center">
+              Vedhæft et billede eller en fil i en tråd for at få det vist her.
+            </Text>
+          </Stack>
+        </Paper>
+      )}
+
+      {items.length > 0 && (
+        <SimpleGrid cols={{ base: 2, sm: 3, md: 4, lg: 5 }} spacing="md">
+          {items.map((item) => (
+            <GalleryTile
+              key={item.id}
+              item={item}
+              onOpenImage={handleImageClick}
+              onOpenDoc={handleDocClick}
+            />
+          ))}
+        </SimpleGrid>
+      )}
+
+      <div ref={sentinelRef} style={{ height: 1 }} />
+
+      {isFetchingNextPage && (
+        <Center>
+          <Loader size="sm" />
+        </Center>
+      )}
+
+      <AttachmentCarousel
+        attachments={carouselAttachments}
+        opened={carouselOpen}
+        onClose={() => setCarouselOpen(false)}
+        initialIndex={carouselIndex}
+      />
+    </Stack>
+  )
+}
+
+interface GalleryTileProps {
+  item: GalleryItem
+
+  onOpenImage: (item: GalleryItem) => void
+
+  onOpenDoc: (item: GalleryItem) => void
+}
+
+function GalleryTile({ item, onOpenImage, onOpenDoc }: GalleryTileProps) {
+  const fileType = getFileType(item.name)
+  const isImage = fileType === "image"
+
+  const FileIcon = getFileIcon(item.name)
+  const iconColor = getFileTypeColor(item.name)
+
+  return (
+    <Stack gap={4}>
+      <Box
+        role="button"
+        tabIndex={0}
+        onClick={() => (isImage ? onOpenImage(item) : onOpenDoc(item))}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            isImage ? onOpenImage(item) : onOpenDoc(item)
+          }
+        }}
+        style={{
+          aspectRatio: "1",
+          width: "100%",
+          overflow: "hidden",
+          borderRadius: "var(--mantine-radius-sm)",
+          border: "1px solid var(--mantine-color-gray-3)",
+          cursor: "pointer",
+          background: "var(--mantine-color-gray-0)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {isImage ? (
+          <Image
+            src={item.file_url}
+            alt={item.name}
+            fit="cover"
+            h="100%"
+            w="100%"
+            loading="lazy"
+          />
+        ) : (
+          <Stack align="center" gap={4} p="xs">
+            <ThemeIcon variant="light" color={iconColor} size="xl" radius="md">
+              <FileIcon size={28} />
+            </ThemeIcon>
+            <Text
+              size="xs"
+              ta="center"
+              lineClamp={2}
+              style={{ wordBreak: "break-word" }}
+            >
+              {item.name}
+            </Text>
+          </Stack>
+        )}
+      </Box>
+
+      <Anchor
+        component={Link}
+        to={`/forum/${item.subgroup_slug}/traad/${item.thread_slug}`}
+        size="xs"
+        c="dimmed"
+        title={item.thread_title}
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {item.thread_title}
+      </Anchor>
+    </Stack>
+  )
+}

--- a/frontend/src/pages/SubgroupPage.tsx
+++ b/frontend/src/pages/SubgroupPage.tsx
@@ -59,6 +59,7 @@ import {
   IconChecks,
   IconCalendarPlus,
   IconLink,
+  IconPhoto,
   IconCopy,
   IconEyeOff,
   IconUsers,
@@ -82,6 +83,8 @@ import { clearDraft, loadDraft, saveDraft } from "../utils/draftStorage"
 import { filterFilesBySize } from "../config"
 
 import { CompactEventCard } from "../components/CompactEventCard"
+
+import GalleryTab from "../components/GalleryTab"
 
 import type { RichTextEditorProps } from "../components/RichTextEditor"
 import { RichTextContent } from "../components/RichTextContent"
@@ -160,9 +163,11 @@ export default function SubgroupPage() {
 
   const activeTab = location.pathname.includes("/dokumenter")
     ? "documents"
-    : location.pathname.includes("/info")
-      ? "info"
-      : "threads"
+    : location.pathname.includes("/galleri")
+      ? "gallery"
+      : location.pathname.includes("/info")
+        ? "info"
+        : "threads"
 
   const [
     createThreadModalOpened,
@@ -790,9 +795,11 @@ When done, print a short summary:
         value={activeTab}
         onChange={(tab) => {
           if (tab === "documents") navigate(`/forum/${slug}/dokumenter`)
+          else if (tab === "gallery") navigate(`/forum/${slug}/galleri`)
           else if (tab === "info") navigate(`/forum/${slug}/info`)
           else navigate(`/forum/${slug}`)
         }}
+        keepMounted={false}
         mb="md"
       >
         <Tabs.List>
@@ -818,6 +825,9 @@ When done, print a short summary:
           </Tabs.Tab>
           <Tabs.Tab value="documents" leftSection={<IconFolder size={16} />}>
             Dokumenter
+          </Tabs.Tab>
+          <Tabs.Tab value="gallery" leftSection={<IconPhoto size={16} />}>
+            Galleri
           </Tabs.Tab>
           <Tabs.Tab value="info" leftSection={<IconLink size={16} />}>
             Links og info
@@ -917,6 +927,10 @@ When done, print a short summary:
               else navigate(`/forum/${slug}/dokumenter/${folderSlug}`)
             }}
           />
+        </Tabs.Panel>
+
+        <Tabs.Panel value="gallery" pt="md">
+          <GalleryTab subgroupSlug={slug!} />
         </Tabs.Panel>
 
         <Tabs.Panel value="info" pt="md">
@@ -1057,6 +1071,10 @@ When done, print a short summary:
         defaultMembersOnly={subgroup?.default_members_only ?? false}
         onSuccess={(thread) => {
           queryClient.invalidateQueries({ queryKey: ["threads", slug] })
+
+          queryClient.invalidateQueries({
+            queryKey: ["subgroup-gallery", slug],
+          })
 
           closeCreateThreadModal()
 

--- a/frontend/src/pages/ThreadPage.tsx
+++ b/frontend/src/pages/ThreadPage.tsx
@@ -494,6 +494,11 @@ export default function ThreadPage() {
       // a reply auto-reopens a closed thread.
       queryClient.invalidateQueries({ queryKey: ["threads"] })
 
+      // Refresh the gallery so new attachments appear without a reload.
+      queryClient.invalidateQueries({
+        queryKey: ["subgroup-gallery", thread!.subgroup_slug],
+      })
+
       clearDraft("reply-" + thread!.id)
 
       setReplySubmitKey((k) => k + 1)
@@ -550,6 +555,10 @@ export default function ThreadPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: threadQueryKey })
 
+      queryClient.invalidateQueries({
+        queryKey: ["subgroup-gallery", thread!.subgroup_slug],
+      })
+
       setEditingPost(null)
 
       setEditContent("")
@@ -582,6 +591,10 @@ export default function ThreadPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: threadQueryKey })
 
+      queryClient.invalidateQueries({
+        queryKey: ["subgroup-gallery", thread!.subgroup_slug],
+      })
+
       closeDeleteModal()
 
       setPostToDelete(null)
@@ -604,6 +617,10 @@ export default function ThreadPage() {
     mutationFn: forumApi.deleteThread,
 
     onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["subgroup-gallery", thread!.subgroup_slug],
+      })
+
       notifications.show({
         title: "Tråd slettet",
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -290,6 +290,28 @@ export interface PostAttachment {
   uploaded_at: string
 }
 
+export interface GalleryItem {
+  id: number
+
+  name: string
+
+  file_url: string
+
+  preview_html?: string
+
+  uploaded_at: string
+
+  uploaded_by: Author | null
+
+  thread_id: number
+
+  thread_slug: string
+
+  thread_title: string
+
+  subgroup_slug: string
+}
+
 export type ReactionType = string
 
 export interface ReactionUser {


### PR DESCRIPTION
## Summary
- New **Galleri** tab next to *Tråde / Dokumenter / Links og info* on each forum subgroup. Shows every attachment posted in any thread of that subgroup, newest first, in a mixed image + document tile grid. Click an image → opens the existing `AttachmentCarousel` lightbox; click a document → opens it in a new tab. Each tile has a clickable thread title underneath for jumping back to the discussion.
- Infinite scroll (60/page) via `IntersectionObserver`. Info banner at the top explains how to add media (vedhæft i en tråd).
- Backend endpoint `GET /api/forum/subgroups/<slug>/gallery/` respects the same `members_only` thread visibility rules as the threads tab.
- Side effect: subgroup `Tabs` switched to `keepMounted={false}` so inactive panels unmount, and post-mutations invalidate the gallery query — new attachments show up without a reload.

## Test plan
- [x] Open the Galleri tab on a subgroup with attachments (e.g. `legeplads-gruppen`) — tiles render in chronological order, banner visible.
- [x] Click an image tile — `AttachmentCarousel` opens at the correct slide; swipe works.
- [x] Click a document tile — file opens in a new tab.
- [x] Click the thread title under a tile — navigates to that thread.
- [x] Reply with a file attachment from a thread, return to the subgroup's Galleri tab — new attachment appears without a reload.
- [x] Empty state on a subgroup with no attachments (e.g. `multibane`) shows the "Ingen medier endnu" card.
- [x] Non-member opening a subgroup with members-only threads sees only public attachments (covered by 7 new pytest cases).
- [x] Mobile viewport (375×812) — 2-column grid, tabs wrap, carousel goes full-screen.
- [x] "Stor skrift og høj kontrast" mode — text scales, layout still works on both viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)