### PR TITLE
Gallery polish: post-scroll, lilac borders, keyboard nav, thread link in carousel

### DIFF
--- a/backend/apps/forum/serializers.py
+++ b/backend/apps/forum/serializers.py
@@ -58,9 +58,13 @@ class GalleryItemSerializer(serializers.ModelSerializer):
 
     uploaded_by = AuthorSerializer(read_only=True)
     file_url = serializers.SerializerMethodField()
+    post_id = serializers.IntegerField(source="post.id", read_only=True)
     thread_id = serializers.IntegerField(source="post.thread.id", read_only=True)
     thread_slug = serializers.CharField(source="post.thread.slug", read_only=True)
     thread_title = serializers.CharField(source="post.thread.title", read_only=True)
+    thread_members_only = serializers.BooleanField(
+        source="post.thread.members_only", read_only=True
+    )
     subgroup_slug = serializers.CharField(source="post.thread.subgroup.slug", read_only=True)
 
     class Meta:
@@ -72,9 +76,11 @@ class GalleryItemSerializer(serializers.ModelSerializer):
             "preview_html",
             "uploaded_at",
             "uploaded_by",
+            "post_id",
             "thread_id",
             "thread_slug",
             "thread_title",
+            "thread_members_only",
             "subgroup_slug",
         ]
 

--- a/backend/apps/forum/views.py
+++ b/backend/apps/forum/views.py
@@ -554,6 +554,11 @@ class SubgroupGalleryView(generics.ListAPIView):
                 visible | Q(post__thread__subgroup_id__in=member_ids) | Q(post__thread__author=user)
             )
 
+        # Sort by parent post creation time, not attachment.uploaded_at. The
+        # scraped/imported data shares one uploaded_at value across all rows,
+        # and even for fresh attachments, "when the post was made" matches the
+        # mental model the user is browsing with. Tie-break on id so the order
+        # is deterministic for posts created in the same second.
         return (
             PostAttachment.objects.filter(post__thread__subgroup=subgroup)
             .filter(visible)
@@ -561,7 +566,7 @@ class SubgroupGalleryView(generics.ListAPIView):
                 "uploaded_by",
                 "post__thread__subgroup",
             )
-            .order_by("-uploaded_at", "-id")
+            .order_by("-post__created_at", "-id")
         )
 
 

--- a/frontend/src/components/AttachmentCarousel.tsx
+++ b/frontend/src/components/AttachmentCarousel.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect } from "react"
 
+import { Link } from "react-router-dom"
+
+import type { EmblaCarouselType } from "embla-carousel"
+
 import {
   Modal,
   Image,
@@ -28,6 +32,7 @@ import {
   IconFileTypePdf,
   IconFileTypeDoc,
   IconFileTypePpt,
+  IconMessage,
 } from "@tabler/icons-react"
 
 import { getFileType, getFileIcon, getFileTypeColor } from "./FilePreview"
@@ -41,6 +46,16 @@ interface Attachment {
   file_url: string
 
   preview_html?: string
+
+  // Optional thread context — present when the carousel is opened from the
+  // gallery, where each slide belongs to a different thread.
+  thread_subgroup_slug?: string
+
+  thread_slug?: string
+
+  post_id?: number
+
+  thread_title?: string
 }
 
 interface AttachmentCarouselProps {
@@ -68,6 +83,33 @@ export function AttachmentCarousel({
     src: string
     name: string
   } | null>(null)
+
+  const [embla, setEmbla] = useState<EmblaCarouselType | null>(null)
+
+  // Arrow keys navigate the carousel while the modal is open. Skip when the
+  // user is typing in a form field so we don't hijack input cursors.
+  useEffect(() => {
+    if (!opened || !embla) return
+
+    const handleKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null
+      const tag = target?.tagName
+      const editable = target?.isContentEditable
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || editable)
+        return
+
+      if (e.key === "ArrowLeft") {
+        e.preventDefault()
+        embla.scrollPrev()
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault()
+        embla.scrollNext()
+      }
+    }
+
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [opened, embla])
 
   // Separate images and other files, images come first
 
@@ -151,6 +193,7 @@ export function AttachmentCarousel({
           nextControlIcon={<IconChevronRight size={24} />}
           previousControlIcon={<IconChevronLeft size={24} />}
           emblaOptions={{ loop: true }}
+          getEmblaApi={setEmbla}
           styles={{
             root: { height: "100%" },
 
@@ -158,7 +201,12 @@ export function AttachmentCarousel({
 
             container: { height: "100%" },
 
-            slide: { height: "100%" },
+            // Reserve a strip at the bottom so the per-slide Download button
+            // doesn't overlap the dot indicators (which float at bottom: 10).
+            slide: {
+              height: "100%",
+              paddingBottom: isMobile ? 0 : 32,
+            },
 
             control: {
               backgroundColor: "var(--mantine-color-default)",
@@ -239,6 +287,26 @@ function SlideContent({
   const fileType = getFileType(attachment.name)
 
   const isPwa = window.matchMedia("(display-mode: standalone)").matches
+
+  // Optional "Gå til tråd" link, rendered next to Download when the carousel
+  // was opened from the gallery (each slide is from a different thread).
+  const hasThreadLink = !!(
+    attachment.thread_slug && attachment.thread_subgroup_slug
+  )
+
+  const threadLinkButton = hasThreadLink ? (
+    <Button
+      component={Link}
+      to={`/forum/${attachment.thread_subgroup_slug}/traad/${attachment.thread_slug}${
+        attachment.post_id ? `#post-${attachment.post_id}` : ""
+      }`}
+      variant="light"
+      size="sm"
+      leftSection={<IconMessage size={16} />}
+    >
+      Gå til tråd
+    </Button>
+  ) : null
 
   // Fetch content for text files
 
@@ -356,7 +424,8 @@ function SlideContent({
             onClick={() => onImageZoom(attachment.file_url, attachment.name)}
           />
         </Box>
-        <Group justify="center" mt="md">
+        <Group justify="center" gap="xs" mt="md">
+          {threadLinkButton}
           <Button
             variant="light"
             size="sm"
@@ -388,15 +457,18 @@ function SlideContent({
           <Text size="lg" fw={500} ta="center">
             {attachment.name}
           </Text>
-          <Button
-            component="a"
-            href={attachment.file_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            leftSection={<IconExternalLink size={16} />}
-          >
-            Åbn PDF
-          </Button>
+          <Group justify="center" gap="xs">
+            {threadLinkButton}
+            <Button
+              component="a"
+              href={attachment.file_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              leftSection={<IconExternalLink size={16} />}
+            >
+              Åbn PDF
+            </Button>
+          </Group>
         </Stack>
       )
     }
@@ -418,7 +490,8 @@ function SlideContent({
             title={attachment.name}
           />
         </Box>
-        <Group justify="center">
+        <Group justify="center" gap="xs">
+          {threadLinkButton}
           <Button
             variant="light"
             size="sm"
@@ -461,7 +534,8 @@ function SlideContent({
             {textContent}
           </Code>
         </ScrollArea>
-        <Group justify="center">
+        <Group justify="center" gap="xs">
+          {threadLinkButton}
           <Button
             variant="light"
             size="sm"
@@ -494,7 +568,8 @@ function SlideContent({
               dangerouslySetInnerHTML={{ __html: attachment.preview_html }}
             />
           </ScrollArea>
-          <Group justify="center">
+          <Group justify="center" gap="xs">
+            {threadLinkButton}
             <Button
               variant="light"
               size="sm"
@@ -525,12 +600,15 @@ function SlideContent({
           <br />
           Download filen for at åbne den.
         </Text>
-        <Button
-          leftSection={<IconDownload size={16} />}
-          onClick={handleDownload}
-        >
-          Download fil
-        </Button>
+        <Group justify="center" gap="xs">
+          {threadLinkButton}
+          <Button
+            leftSection={<IconDownload size={16} />}
+            onClick={handleDownload}
+          >
+            Download fil
+          </Button>
+        </Group>
       </Stack>
     )
   }
@@ -555,12 +633,15 @@ function SlideContent({
           <br />
           Download filen for at åbne den.
         </Text>
-        <Button
-          leftSection={<IconDownload size={16} />}
-          onClick={handleDownload}
-        >
-          Download fil
-        </Button>
+        <Group justify="center" gap="xs">
+          {threadLinkButton}
+          <Button
+            leftSection={<IconDownload size={16} />}
+            onClick={handleDownload}
+          >
+            Download fil
+          </Button>
+        </Group>
       </Stack>
     )
   }
@@ -588,9 +669,15 @@ function SlideContent({
         <br />
         Download filen for at åbne den.
       </Text>
-      <Button leftSection={<IconDownload size={16} />} onClick={handleDownload}>
-        Download fil
-      </Button>
+      <Group justify="center" gap="xs">
+        {threadLinkButton}
+        <Button
+          leftSection={<IconDownload size={16} />}
+          onClick={handleDownload}
+        >
+          Download fil
+        </Button>
+      </Group>
     </Stack>
   )
 }

--- a/frontend/src/components/GalleryTab.tsx
+++ b/frontend/src/components/GalleryTab.tsx
@@ -16,9 +16,10 @@ import {
   Loader,
   Paper,
   ThemeIcon,
+  Tooltip,
 } from "@mantine/core"
 
-import { IconInfoCircle, IconPhoto } from "@tabler/icons-react"
+import { IconInfoCircle, IconPhoto, IconEyeOff } from "@tabler/icons-react"
 
 import { forumApi } from "../api/forum"
 
@@ -105,6 +106,10 @@ export default function GalleryTab({ subgroupSlug }: GalleryTabProps) {
         name: item.name,
         file_url: item.file_url,
         preview_html: item.preview_html,
+        thread_subgroup_slug: item.subgroup_slug,
+        thread_slug: item.thread_slug,
+        thread_title: item.thread_title,
+        post_id: item.post_id,
       })),
     [imageItems],
   )
@@ -189,8 +194,10 @@ function GalleryTile({ item, onOpenImage, onOpenDoc }: GalleryTileProps) {
   const FileIcon = getFileIcon(item.name)
   const iconColor = getFileTypeColor(item.name)
 
+  const isPrivate = item.thread_members_only
+
   return (
-    <Stack gap={4}>
+    <Stack gap={4} style={{ position: "relative" }}>
       <Box
         role="button"
         tabIndex={0}
@@ -206,7 +213,9 @@ function GalleryTile({ item, onOpenImage, onOpenDoc }: GalleryTileProps) {
           width: "100%",
           overflow: "hidden",
           borderRadius: "var(--mantine-radius-sm)",
-          border: "1px solid var(--mantine-color-gray-3)",
+          border: isPrivate
+            ? "2px solid var(--mantine-color-grape-8)"
+            : "1px solid var(--mantine-color-gray-3)",
           cursor: "pointer",
           background: "var(--mantine-color-gray-0)",
           display: "flex",
@@ -240,9 +249,32 @@ function GalleryTile({ item, onOpenImage, onOpenDoc }: GalleryTileProps) {
         )}
       </Box>
 
+      {isPrivate && (
+        <Tooltip label="Kun for medlemmer">
+          <Box
+            style={{
+              position: "absolute",
+              top: -8,
+              left: -8,
+              width: 22,
+              height: 22,
+              borderRadius: "50%",
+              backgroundColor: "var(--mantine-color-grape-8)",
+              color: "white",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              zIndex: 1,
+            }}
+          >
+            <IconEyeOff size={14} />
+          </Box>
+        </Tooltip>
+      )}
+
       <Anchor
         component={Link}
-        to={`/forum/${item.subgroup_slug}/traad/${item.thread_slug}`}
+        to={`/forum/${item.subgroup_slug}/traad/${item.thread_slug}#post-${item.post_id}`}
         size="xs"
         c="dimmed"
         title={item.thread_title}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -303,11 +303,15 @@ export interface GalleryItem {
 
   uploaded_by: Author | null
 
+  post_id: number
+
   thread_id: number
 
   thread_slug: string
 
   thread_title: string
+
+  thread_members_only: boolean
 
   subgroup_slug: string
 }


### PR DESCRIPTION
Follow-up refinements on top of #85.

## Summary
- **Sort by post date.** Gallery now orders by parent post's `created_at` instead of `attachment.uploaded_at` — imported attachments all share one migration timestamp, so the old sort collapsed to insertion order. New sort puts each file next to its actual reply date.
- **Scroll-to-post.** Tile link and carousel "Gå til tråd" both include `#post-N` so ThreadPage's existing scroll-and-highlight effect carries the user straight to the reply.
- **Lilac border on private tiles.** Tiles whose source thread is `members_only` get the same grape-8 border + EyeOff badge already used in the threads list.
- **Carousel arrow keys.** ArrowLeft / ArrowRight browse slides (with loop). Guarded against hijacking input cursors.
- **Download button no longer overlaps indicator dots.** 32px reserved at the slide bottom on desktop.
- **"Gå til tråd" in carousel.** When the carousel is opened from the gallery, each slide gains a Gå til tråd action next to Download. Added to every slide variant (image / PDF / text / Word / PowerPoint / generic). Post-level carousels in ThreadPage don't pass thread context, so the button stays hidden in the existing flow.

## Test plan
- [x] Open `/forum/<slug>/galleri` — tiles are in newest-post-first order; private tiles have a lilac 2px border + EyeOff badge.
- [x] Click a tile's thread title — lands on the thread, page scrolls to the specific reply.
- [x] Open the carousel from a gallery tile — "Gå til tråd" appears next to Download; both clear of the dot indicators on desktop and mobile.
- [x] ArrowLeft / ArrowRight in the carousel move slides; wraps at the ends.
- [x] "Stor skrift og høj kontrast" — buttons stay side-by-side and tile borders remain visible on both viewports.
- [x] Open an attachment from a regular post in ThreadPage — Gå til tråd button does NOT appear (we're already on the thread).
- [x] Non-member opening a subgroup with members-only threads still sees only public tiles (covered by existing pytest cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)