### PR TITLE
ci: deploy only on develop, CI-only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -116,7 +116,7 @@ jobs:
   build-push:
     name: Build & Push Images
     needs: [backend-lint, backend-test, frontend-lint, frontend-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy-test2.yml
+++ b/.github/workflows/deploy-test2.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main]
+    branches: [develop]
 
 jobs:
   deploy:


### PR DESCRIPTION
Auto-deploy now fires solely on commits to develop. main still runs full CI (lint/test) but no longer builds images or deploys.