### PR TITLE
The bug

### DIFF
--- a/frontend/src/hooks/usePushSubscriptionSync.ts
+++ b/frontend/src/hooks/usePushSubscriptionSync.ts
@@ -131,6 +131,11 @@ export function usePushSubscriptionSync() {
 
   const lastSyncRef = useRef<number>(0)
 
+  // Target path requested by a tapped notification, held until the page is
+  // actually visible (see the NAVIGATE handler below).
+
+  const pendingNavRef = useRef<string | null>(null)
+
   useEffect(() => {
     // Don't sync push subscriptions when not authenticated — API calls would
 
@@ -158,6 +163,18 @@ export function usePushSubscriptionSync() {
       syncPushSubscription()
     }
 
+    /** Navigate to a path requested by a tapped notification, if any. */
+
+    function flushPendingNavigation() {
+      const target = pendingNavRef.current
+
+      if (!target) return
+
+      pendingNavRef.current = null
+
+      navigate(target, { replace: false })
+    }
+
     // Sync on startup (delayed to avoid slowing down app init)
 
     const timer = setTimeout(() => {
@@ -170,6 +187,12 @@ export function usePushSubscriptionSync() {
 
     const handleVisibility = () => {
       if (document.visibilityState === "visible") {
+        // The page just became visible — if a notification tap is waiting to
+        // navigate, do it now (after iOS has finished restoring the previous
+        // route on a warm resume).
+
+        flushPendingNavigation()
+
         debouncedSync()
       }
     }
@@ -203,7 +226,18 @@ export function usePushSubscriptionSync() {
         try {
           const url = new URL(event.data.url)
 
-          navigate(url.pathname + url.search + url.hash, { replace: false })
+          pendingNavRef.current = url.pathname + url.search + url.hash
+
+          // Navigate immediately if the page is visible. If it's still hidden,
+          // iOS is bringing a warm PWA to the foreground and will restore the
+          // previous route on resume, which would clobber an immediate
+          // navigate(). Defer to the next visibilitychange so our navigation
+          // wins. This is the warm-app case that previously just opened the app
+          // without navigating.
+
+          if (document.visibilityState === "visible") {
+            flushPendingNavigation()
+          }
         } catch {
           // Malformed URL — ignore
         }

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -115,6 +115,27 @@ self.addEventListener("notificationclick", (event: NotificationEvent) => {
           client.url.startsWith(self.location.origin),
         )
 
+        // On Firefox Android, client.focus() brings the Firefox browser window to the
+        // foreground (showing a random tab) instead of the PWA standalone window.
+        // Skip focus() on Firefox and fall through to openWindow() instead, which
+        // will at least navigate Firefox to the correct page.
+
+        const isFirefox =
+          self.navigator?.userAgent?.includes("Firefox") ?? false
+
+        // Focus an existing window BEFORE posting the navigate message. iOS
+        // freezes a backgrounded PWA's JavaScript and can drop messages posted
+        // while it is frozen; focusing first wakes the page so the message is
+        // reliably delivered.
+
+        if (appClients.length > 0 && !isFirefox) {
+          try {
+            await appClients[0].focus()
+          } catch {
+            // focus() may be rejected if the browser doesn't allow it
+          }
+        }
+
         // Post navigate message to ALL existing app clients so the PWA
 
         // receives it regardless of which window gets focused (Firefox
@@ -129,21 +150,7 @@ self.addEventListener("notificationclick", (event: NotificationEvent) => {
           }
         }
 
-        // On Firefox Android, client.focus() brings the Firefox browser window to the
-        // foreground (showing a random tab) instead of the PWA standalone window.
-        // Skip focus() on Firefox and fall through to openWindow() instead, which
-        // will at least navigate Firefox to the correct page.
-
-        const isFirefox =
-          self.navigator?.userAgent?.includes("Firefox") ?? false
-
         if (appClients.length > 0 && !isFirefox) {
-          try {
-            await appClients[0].focus()
-          } catch {
-            // focus() may be rejected if the browser doesn't allow it
-          }
-
           return
         }
 


### PR DESCRIPTION
  Tapping a push notification runs notificationclick in the service worker (frontend/src/sw.ts), which takes one of two paths:

  - App closed (cold): no window exists → clients.openWindow(url) opens the PWA directly at the target page. Works.
  - App open / recently used (warm): a window exists → the SW postMessages a NAVIGATE and the client (usePushSubscriptionSync.ts) does a React Router navigate(). This is the broken path on iOS.

  The warm path failed on iOS for two reasons:
  1. The SW posted the message before focus(), i.e. while iOS still has the backgrounded PWA's JS frozen — so the message could be dropped.
  2. When a warm PWA returns to the foreground, iOS restores the route it had when backgrounded, clobbering an immediate navigate(). A fully-closed app has nothing to restore, which is exactly why closing first "fixes" it.

  The fix (two files)

  sw.ts — focus the existing window first (waking the page), then post NAVIGATE, so the message is reliably delivered. Firefox behavior is unchanged (still falls through to openWindow).

  usePushSubscriptionSync.ts — instead of navigating the instant the message arrives, store the target in pendingNavRef and only navigate when the page is actually visible. If it's
  already visible, navigate now; if hidden, defer to the next visibilitychange → visible (which fires after iOS finishes its restore), so our navigation wins.

  One caveat — needs device testing

  I can't reproduce iOS PWA freeze/restore behavior in this environment, so this is a well-reasoned fix against the most likely root cause, not something I verified on hardware. It can
  only be confirmed on your iPhone: open the app, interact, leave it backgrounded (don't close it), then tap a notification and check it lands on the right page. Since service-worker
  changes are involved, you'll need the new SW to actually activate — the app's version-check force-reload should handle that, but if it misbehaves, fully closing and reopening once
  will pick up the new SW.