### PR TITLE
Fix: improve calendar location text contrast

### DIFF
--- a/frontend/src/components/CompactEventCard.tsx
+++ b/frontend/src/components/CompactEventCard.tsx
@@ -123,7 +123,6 @@ export function CompactEventCard({
               <LocationText
                 location={event.resolved_location}
                 size="sm"
-                c="dimmed"
                 truncate
               />
             </Group>

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -437,7 +437,6 @@ export default function CalendarPage() {
                               <LocationText
                                 location={ev.resolved_location}
                                 size="sm"
-                                c="dimmed"
                                 lineClamp={1}
                               />
                             </Group>


### PR DESCRIPTION
## Problem

The calendar event location text ("lokalitetstekst") was rendered with `c="dimmed"`, which resolves to Mantine's `--mantine-color-dimmed` (~`gray.6`, `#868e96`). On white that gives roughly a 3.5:1 contrast ratio — below the WCAG AA threshold of 4.5:1 for normal text — so it was hard to read in light theme and a touch unclear in dark theme.

## Change

Removed `c="dimmed"` from the two `<LocationText>` usages so the location inherits the default body text color (strong contrast in both themes):

- `frontend/src/components/CompactEventCard.tsx` — kept `size="sm"` and `truncate`.
- `frontend/src/pages/CalendarPage.tsx` (list view) — kept `size="sm"` and `lineClamp={1}`.

The text still reads as visually secondary because it stays `size="sm"` and is prefixed with the muted map-pin icon. The dashboard `EventPreview` (`size="xs"` in a denser widget) was intentionally left dimmed per the handoff's optional note.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings, 0 errors)
- `npm run format:check` — pass
- `npm run test:run` — pass (405 tests across 41 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)