### PR TITLE
Add Danish flag for birthdays today

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1099,7 +1099,7 @@ function BirthdayPreview({ birthday }: BirthdayPreviewProps) {
   let dateLabel: string
 
   if (daysUntil === 0) {
-    dateLabel = "I dag!"
+    dateLabel = "🇩🇰 I dag!"
   } else if (daysUntil === 1) {
     dateLabel = "I morgen"
   } else {


### PR DESCRIPTION
## Summary

Shows a Danish flag 🇩🇰 in the dashboard "Fødselsdage" widget when a resident has a birthday **today**. This reflects the Danish tradition of raising Dannebrog on someone's birthday — a small, tasteful, celebratory touch requested by a resident.

## Change

In `BirthdayPreview` (`frontend/src/pages/DashboardPage.tsx`), the `daysUntil === 0` case now sets the badge label to `"🇩🇰 I dag!"` (was `"I dag!"`). Only the today case gets the flag — "I morgen" and "Om N dage" are unchanged.

This follows the handoff's recommended Option A (minimal, low-risk: flag on the existing pink "I dag!" badge).

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings, 0 errors)
- `npm run format:check` — pass (all files correctly formatted)
- `npm run test:run` — pass (405 tests, 41 files). `DashboardPage.test.tsx` only asserts on the "Fødselsdage" heading, not the birthday label text, so no test update was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)