### PR TITLE
Add 'Se Fælles' shortcut on dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -195,6 +195,35 @@ describe("DashboardPage", () => {
     expect(screen.getByText(/this is a test forum post/i)).toBeInTheDocument()
   })
 
+  // Fælles shortcut buttons
+
+  it("should show both 'Skriv på Fælles' and 'Se Fælles' shortcuts", async () => {
+    mockGetSubgroups.mockResolvedValue([
+      {
+        id: 1,
+        name: "Fælles",
+        slug: "faelles",
+        is_member: false,
+        is_subscribed: false,
+        unread_thread_count: 0,
+        last_activity_at: null,
+      },
+    ])
+
+    render(<DashboardPage />)
+
+    const writeLink = await screen.findByRole("link", {
+      name: /skriv på fælles/i,
+    })
+    const viewLink = await screen.findByRole("link", { name: /se fælles/i })
+
+    // "Skriv på Fælles" opens the new-thread composer (?nytraad=1)
+    expect(writeLink).toHaveAttribute("href", "/forum/faelles?nytraad=1")
+
+    // "Se Fælles" opens the group's thread list (no ?nytraad=1)
+    expect(viewLink).toHaveAttribute("href", "/forum/faelles")
+  })
+
   // Birthday Tests
 
   it("should show birthday section", async () => {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -488,15 +488,25 @@ export default function DashboardPage() {
   return (
     <>
       {faellesGroup && (
-        <Button
-          component={Link}
-          to={`/forum/${faellesGroup.slug}?nytraad=1`}
-          leftSection={<IconPencil size={16} />}
-          size="sm"
-          mb="xl"
-        >
-          Skriv på Fælles
-        </Button>
+        <Group mb="xl" gap="sm">
+          <Button
+            component={Link}
+            to={`/forum/${faellesGroup.slug}?nytraad=1`}
+            leftSection={<IconPencil size={16} />}
+            size="sm"
+          >
+            Skriv på Fælles
+          </Button>
+          <Button
+            component={Link}
+            to={`/forum/${faellesGroup.slug}`}
+            variant="light"
+            leftSection={<IconUsers size={16} />}
+            size="sm"
+          >
+            Se Fælles
+          </Button>
+        </Group>
       )}
 
       {hasError && (


### PR DESCRIPTION
## What

Adds a **"Se Fælles"** button next to the existing **"Skriv på Fælles"** button on the dashboard (`DashboardPage.tsx`). It links to the Fælles forum group's thread list (`/forum/<faelles-slug>`, without `?nytraad=1`), giving a short path to *view* Fælles — addressing the report that it's "for lang vej til Fælles på mobil".

## How

- Wrapped the two buttons in a Mantine `Group` (`mb="xl"` moved from the old single button to the wrapper, so spacing below is unchanged). `Group` wraps its children by default, so the buttons wrap sensibly on narrow mobile widths.
- "Skriv på Fælles" still opens the new-thread composer (`?nytraad=1`); "Se Fælles" (light variant, `IconUsers`) opens the group thread list.
- Both are guarded by `faellesGroup` exactly as before — no change to when they show.
- No new imports needed (`Group`, `Button`, `IconUsers`, `IconPencil` were already imported).
- Added a test asserting both shortcuts render with the correct `href`s (`/forum/faelles?nytraad=1` and `/forum/faelles`).

## Verified

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings, 0 errors)
- `npm run format:check` — pass
- `npm run test:run` — pass (406 tests, 41 files), including the new Fælles shortcut test

🤖 Generated with [Claude Code](https://claude.com/claude-code)