### PR TITLE
Fix: back from search result reopens search

### DIFF
--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -178,6 +178,11 @@ export function GlobalSearch({ onAction }: GlobalSearchProps) {
 
   const closingFromHistoryRef = useRef(false)
 
+  // Track whether the spotlight is currently open so popstate can decide
+  // between reopening (returning to the pushed entry) and closing.
+
+  const openRef = useRef(false)
+
   // Track visual viewport height so the actions list fits above the keyboard
 
   const [vpHeight, setVpHeight] = useState<number | null>(null)
@@ -197,8 +202,22 @@ export function GlobalSearch({ onAction }: GlobalSearchProps) {
   }, [isMobile])
 
   useEffect(() => {
-    const handlePopState = () => {
-      if (historyPushedRef.current) {
+    const handlePopState = (e: PopStateEvent) => {
+      // Returning (Back) onto the search history entry while the spotlight is
+      // closed → reopen the search with the retained query.
+      if (
+        (e.state as { spotlight?: boolean } | null)?.spotlight &&
+        !openRef.current
+      ) {
+        historyPushedRef.current = true
+
+        spotlight.open()
+
+        return
+      }
+
+      // Back pressed while the spotlight is open → close it (existing behaviour).
+      if (historyPushedRef.current && openRef.current) {
         closingFromHistoryRef.current = true
 
         historyPushedRef.current = false
@@ -268,13 +287,12 @@ export function GlobalSearch({ onAction }: GlobalSearchProps) {
 
         spotlight.close()
       } else {
-        // Replace the spotlight history entry with the destination so the back-button
+        // Push the destination on top of the spotlight history entry so Back
+        // returns to the search (which reopens via the popstate handler).
 
-        // goes to the originating page, not the ghost spotlight entry.
+        historyPushedRef.current = false // prevents onSpotlightClose from popping the entry
 
-        historyPushedRef.current = false
-
-        navigate(item.url, { replace: true })
+        navigate(item.url)
 
         spotlight.close()
       }
@@ -430,11 +448,21 @@ export function GlobalSearch({ onAction }: GlobalSearchProps) {
         highlightQuery
         fullScreen={isMobile}
         onSpotlightOpen={() => {
-          history.pushState({ spotlight: true }, "")
+          openRef.current = true
 
-          historyPushedRef.current = true
+          // Only push a new ghost entry when one isn't already in place. When
+          // reopening via Back (popstate), historyPushedRef is already set and
+          // we are sitting on the existing spotlight entry — pushing again would
+          // leave a stale entry behind.
+          if (!historyPushedRef.current) {
+            history.pushState({ spotlight: true }, "")
+
+            historyPushedRef.current = true
+          }
         }}
         onSpotlightClose={() => {
+          openRef.current = false
+
           if (closingFromHistoryRef.current) {
             closingFromHistoryRef.current = false
           } else if (historyPushedRef.current) {


### PR DESCRIPTION
## Problem

After running a global search from the front page and clicking a (non-file) result, pressing browser/device **Back** dropped the user on the bare front page and the search was gone. Residents expect Back to return to the search results, with the previous query retained ("Husk seneste søgning").

Root cause: `handleAction` navigated with `replace: true`, which overwrote the spotlight's pushed history entry with the destination, leaving the stack `[front] → [detail]`.

## Fix (`frontend/src/components/GlobalSearch.tsx`)

- Added an `openRef` so the `popstate` handler can distinguish "spotlight open" from "spotlight closed".
- Reworked `handlePopState`: returning onto the pushed `{ spotlight: true }` entry while the spotlight is **closed** now reopens it (with the retained `query` state, whose results are cached); pressing Back while it is **open** still closes it as before.
- Changed the non-file result click from `navigate(url, { replace: true })` to a normal push, keeping the spotlight's ghost entry beneath the destination.
- Guarded `onSpotlightOpen`'s `history.pushState` so the reopen-via-Back path does not stack a second ghost entry.

The **file-preview** branch (relies on `onSpotlightClose` → `history.back()`) and the **"Avanceret søgning"** link are left unchanged.

## Resulting history-stack behavior

- Open search from front page → `[front] → [ghost(spotlight)]`.
- Click a hit → `[front] → [ghost] → [detail]`, spotlight closed.
- Back → pops to `[ghost]`, popstate reopens the spotlight with the last query/results.
- Back again → pops to `[front]`, spotlight closes.
- Open then Back without selecting → spotlight just closes (no stray entry).

## Verified

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings, 0 errors)
- `npm run format:check` — pass
- `npm run test:run` — pass (405 tests, 41 files). The lone "unhandled error" is a pre-existing Mantine Transition teardown-timing artifact in `RegisterPage.test.tsx`, unrelated to this change.
- Traced all three regression paths (close-on-Back, file preview, "Avanceret søgning") to confirm none break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)