### PR TITLE
Hide 'Åbn' button for docx on desktop

### DIFF
--- a/frontend/src/components/FilePreview.tsx
+++ b/frontend/src/components/FilePreview.tsx
@@ -347,17 +347,27 @@ export function FileActionButtons({
 
   extra,
 }: FileActionButtonsProps) {
+  const isTouch = useMediaQuery("(pointer: coarse)")
+
+  // On desktop, "Åbn" only adds value for PDFs (opens in a new tab). For
+  // word/powerpoint/other it just duplicates "Gem", and can silently no-op via
+  // navigator.share — so hide it there. Always show it on touch devices.
+  // useMediaQuery is undefined on first render (falsy) → safe desktop default.
+  const showOpen = isTouch || actions.fileType === "pdf"
+
   return (
     <Group justify="center" gap="xs">
       {extra}
-      <Button
-        size={size}
-        leftSection={<IconExternalLink size={16} />}
-        onClick={actions.handleOpen}
-        disabled={actions.actionsDisabled}
-      >
-        Åbn
-      </Button>
+      {showOpen && (
+        <Button
+          size={size}
+          leftSection={<IconExternalLink size={16} />}
+          onClick={actions.handleOpen}
+          disabled={actions.actionsDisabled}
+        >
+          Åbn
+        </Button>
+      )}
       <Button
         size={size}
         variant="light"


### PR DESCRIPTION
## Problem

When opening a `.docx` (e.g. an old doc migrated from the previous intra without an inline preview), clicking **"Åbn"** on desktop does nothing visible. On desktop the share-sheet path is skipped and, for non-PDF types, it falls through to a plain download — so "Åbn" is identical to "Gem", and on some browsers `navigator.canShare` returns true while `navigator.share` silently rejects, making the click appear to no-op.

Reported by Kasper Eriksen. Maintainer decision in-thread: "Åbn er vidst mest en mobil ting som nok bør skjules på desktop" — and "Gem" works and must stay.

## Fix

In `frontend/src/components/FilePreview.tsx`, `FileActionButtons` now hides the **"Åbn"** button on desktop for non-PDF file types:

```tsx
const isTouch = useMediaQuery("(pointer: coarse)")
const showOpen = isTouch || actions.fileType === "pdf"
```

- **Touch devices** (mobile/tablet): "Åbn" still shows for all types (uses the OS share sheet).
- **PDFs on desktop**: "Åbn" still shows — it opens the PDF in a new tab (genuinely useful, distinct from "Gem").
- **Word/PowerPoint/other on desktop**: "Åbn" is hidden (it only duplicated "Gem").
- **"Gem"** is unchanged everywhere.

`useMediaQuery` returns `undefined` on first render, which is falsy — so the safe desktop default (hide "Åbn" for non-PDF) is the initial state. No backend change; `handleOpen` logic untouched.

## Verified

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings, 0 errors)
- `npm run format:check` — pass
- `npm run test:run` — pass (405 tests, 41 files). One pre-existing teardown-timing artifact in `RegisterPage.test.tsx` (Mantine Transition timer firing post-teardown), unrelated to this change; suite reports passing.
- Logic confirms PDFs and touch devices still render "Åbn"; non-PDF desktop hides it; "Gem" always present. All consumers (`FilePreviewModal`, `AttachmentCarousel`, global search preview) use the same `FileActionButtons` so behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)