### PR TITLE
Fix: show calendar current-time line only on today

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -52,6 +52,20 @@ h1, h2, h3, h4, h5, h6 {
   transform: rotate(90deg);
 }
 
+/* macOS-Calendar behaviour for the current-time line. @mantine/schedule draws the
+   indicator as a full-width root (left:0; right:0) whose ::before paints a faint
+   (opacity 0.2) red line across ALL day columns, plus a separate solid line
+   (currentTimeIndicatorLine) constrained to today's column. Hiding the root's
+   ::before removes the cross-day line so the red line only shows on today; the
+   solid today-only line stays.
+   NB: the static selector is namespaced by the view (WeekView reused by Day view),
+   so it renders as `mantine-WeekView-currentTimeIndicator`, NOT
+   `mantine-CurrentTimeIndicator-currentTimeIndicator`. The exact class token below
+   matches only the root element, not the *Line/*Thumb/*Bubble children. */
+.schedule-wrapper .mantine-WeekView-currentTimeIndicator::before {
+  display: none;
+}
+
 /* Result rows on advanced search page — give the button-styled boxes tap/hover
    feedback so it's obvious they're interactive. */
 .advanced-search-result {


### PR DESCRIPTION
## Problem

In the calendar (`/kalender`) week view, the red current-time ("now") line was drawn across **all 7 day columns** (faint on other days, solid on today). It should only appear on today's column, like macOS Calendar. Reported by Carl MM Kobel.

## Root cause

`@mantine/schedule` (pinned `9.0.0-alpha.1`) builds the current-time indicator from two layers:
- The **root** element (`left: 0; right: 0`, full width) whose `::before` pseudo-element paints a faint full-width red line (`inset: 0; opacity: 0.2`) across every day column.
- A separate **solid line** (`currentTimeIndicatorLine`) constrained to today's column via `inset-inline-start/end` offsets.

The faint cross-day `::before` line is what was reported.

## Fix

Scoped CSS rule in `frontend/src/index.css` (next to the existing `.schedule-wrapper` overrides) hiding the root's `::before`. The indicator stays enabled (`withCurrentTimeIndicator` untouched) and the solid today-only line remains:

```css
.schedule-wrapper .mantine-WeekView-currentTimeIndicator::before {
  display: none;
}
```

## Selector verification (important)

The handoff proposed `mantine-CurrentTimeIndicator-currentTimeIndicator` (and a `[class*="CurrentTimeIndicator-currentTimeIndicator"]` fallback). I verified against the **actually rendered DOM** (rendering `<Schedule>` through the app's own `MantineProvider`, identical to production) and found **both proposed selectors match 0 elements**: the view re-namespaces the indicator's static selector, so the root renders as:

```
class="m_74c54f2d mantine-WeekView-currentTimeIndicator"
```

`WeekView` is also reused by the **Day** view, so the same class applies there. The chosen exact-token selector `.mantine-WeekView-currentTimeIndicator`:
- matches **exactly one** element — the hashed `m_74c54f2d` root that owns the `::before`;
- does **not** match the `...currentTimeIndicatorLine` / `...Thumb` / `...TimeBubble` children (different class tokens), so the solid today line is untouched.

I also confirmed the rule is present in the production-built CSS bundle (`dist/assets/*.css`), and the dev server serves the page (HTTP 200).

## Checks (all from `frontend/`)

- `npm run typecheck` — pass
- `npm run lint` — pass (0 warnings, 0 errors)
- `npm run format:check` — pass
- `npm run test:run` — pass (405 tests, 41 files)
- `npm run build` — clean build

## Files changed

- `frontend/src/index.css` (CSS-only, +14 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)