### PR TITLE
Refine mark-as-unread: per-message action + latest-only default

### DIFF
--- a/backend/apps/messaging/tests.py
+++ b/backend/apps/messaging/tests.py
@@ -233,6 +233,29 @@ class TestMarkMessagesUnreadAPI:
         assert not MessageReadStatus.objects.filter(message=message, user=second_user).exists()
         assert api_client.get("/api/messages/unread-count/").json()["unread_count"] == 1
 
+    def test_mark_unread_only_affects_latest_message(
+        self, api_client, user, second_user, conversation, message
+    ):
+        """Marking a conversation unread clears only the latest message, not all."""
+        # A second, later message from the other participant.
+        latest = Message.objects.create(
+            conversation=conversation,
+            sender=user,
+            content="A later message",
+        )
+
+        api_client.force_authenticate(user=second_user)
+        api_client.post(f"/api/messages/conversations/{conversation.id}/read/")
+
+        response = api_client.post(f"/api/messages/conversations/{conversation.id}/unread/")
+        assert response.status_code == 200
+        assert response.json()["marked_unread"] == 1
+
+        # Only the latest message is unread; the earlier one stays read.
+        assert not MessageReadStatus.objects.filter(message=latest, user=second_user).exists()
+        assert MessageReadStatus.objects.filter(message=message, user=second_user).exists()
+        assert api_client.get("/api/messages/unread-count/").json()["unread_count"] == 1
+
     def test_mark_unread_leaves_own_messages_untouched(
         self, api_client, second_user, conversation, message
     ):
@@ -265,6 +288,48 @@ class TestMarkMessagesUnreadAPI:
         """Users cannot mark a conversation they're not part of as unread."""
         api_client.force_authenticate(user=admin_user)
         response = api_client.post(f"/api/messages/conversations/{conversation.id}/unread/")
+        assert response.status_code == 404
+
+
+class TestMarkMessageUnreadAPI:
+    """Tests for the per-message Mark Unread API endpoint."""
+
+    def test_mark_message_unread(self, api_client, second_user, conversation, message):
+        """Reading then marking a single message unread makes it unread again."""
+        api_client.force_authenticate(user=second_user)
+
+        api_client.post(f"/api/messages/conversations/{conversation.id}/read/")
+        assert MessageReadStatus.objects.filter(message=message, user=second_user).exists()
+
+        response = api_client.post(f"/api/messages/messages/{message.id}/unread/")
+        assert response.status_code == 200
+        assert response.json()["marked_unread"] == 1
+
+        assert not MessageReadStatus.objects.filter(message=message, user=second_user).exists()
+        assert api_client.get("/api/messages/unread-count/").json()["unread_count"] == 1
+
+    def test_mark_own_message_unread_is_noop(self, api_client, second_user, conversation):
+        """Marking one's own message unread is a no-op (own messages aren't tracked)."""
+        own_message = Message.objects.create(
+            conversation=conversation,
+            sender=second_user,
+            content="My own message",
+        )
+        api_client.force_authenticate(user=second_user)
+
+        response = api_client.post(f"/api/messages/messages/{own_message.id}/unread/")
+        assert response.status_code == 200
+        assert response.json()["marked_unread"] == 0
+
+    def test_mark_message_unread_unauthenticated(self, api_client, message):
+        """Unauthenticated users cannot mark a message unread."""
+        response = api_client.post(f"/api/messages/messages/{message.id}/unread/")
+        assert response.status_code == 401
+
+    def test_cannot_mark_message_in_others_conversation(self, api_client, admin_user, message):
+        """Users cannot mark a message in a conversation they're not part of."""
+        api_client.force_authenticate(user=admin_user)
+        response = api_client.post(f"/api/messages/messages/{message.id}/unread/")
         assert response.status_code == 404
 
 

--- a/backend/apps/messaging/urls.py
+++ b/backend/apps/messaging/urls.py
@@ -11,6 +11,7 @@ from .views import (
     LeaveConversationView,
     MarkMessagesReadView,
     MarkMessagesUnreadView,
+    MarkMessageUnreadView,
     MessageEditView,
     MessageListCreateView,
     MessageReactionToggleView,
@@ -63,5 +64,10 @@ urlpatterns = [
         "messages/<int:message_id>/react/",
         MessageReactionToggleView.as_view(),
         name="message-react",
+    ),
+    path(
+        "messages/<int:message_id>/unread/",
+        MarkMessageUnreadView.as_view(),
+        name="message-mark-unread",
     ),
 ]

--- a/backend/apps/messaging/views.py
+++ b/backend/apps/messaging/views.py
@@ -315,7 +315,13 @@ class MarkMessagesReadView(APIView):
 
 
 class MarkMessagesUnreadView(APIView):
-    """Mark a conversation as unread (delete this user's read statuses)."""
+    """Mark a conversation as unread.
+
+    By default this only clears the read status of the latest message from
+    another participant, so the conversation reappears as unread (with one
+    unread message) — a reminder to reply — without resurfacing the whole
+    history. Own messages are never tracked as unread.
+    """
 
     permission_classes = [permissions.IsAuthenticated]
 
@@ -324,17 +330,35 @@ class MarkMessagesUnreadView(APIView):
             Conversation.objects.filter(participants=request.user),
             pk=conversation_id,
         )
-        # Delete this user's read statuses for messages from others so the
-        # conversation reappears as unread. Own messages are never tracked as
-        # unread, so exclude them to leave their read statuses untouched.
-        deleted, _ = (
-            MessageReadStatus.objects.filter(
-                user=request.user,
-                message__conversation=conversation,
-            )
-            .exclude(message__sender=request.user)
-            .delete()
+        latest = (
+            conversation.messages.exclude(sender=request.user)
+            .order_by("-created_at", "-id")
+            .first()
         )
+        if latest is None:
+            return Response({"marked_unread": 0})
+        deleted, _ = MessageReadStatus.objects.filter(user=request.user, message=latest).delete()
+        return Response({"marked_unread": deleted})
+
+
+class MarkMessageUnreadView(APIView):
+    """Mark a single message as unread for the current user.
+
+    Deletes the user's read status for that message so the conversation
+    reappears as unread. Own messages are never tracked as unread, so marking
+    one is a no-op.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request: Request, message_id: int) -> Response:
+        message = get_object_or_404(
+            Message.objects.filter(conversation__participants=request.user),
+            pk=message_id,
+        )
+        if message.sender_id == request.user.id:
+            return Response({"marked_unread": 0})
+        deleted, _ = MessageReadStatus.objects.filter(user=request.user, message=message).delete()
         return Response({"marked_unread": deleted})
 
 

--- a/frontend/src/api/messaging.ts
+++ b/frontend/src/api/messaging.ts
@@ -145,10 +145,16 @@ export const messagingApi = {
     return response.data
   },
 
-  // Mark a conversation as unread (delete this user's read statuses)
+  // Mark a conversation as unread (clears the latest message's read status)
 
   markUnread: async (conversationId: number): Promise<void> => {
     await apiClient.post(`/messages/conversations/${conversationId}/unread/`)
+  },
+
+  // Mark a single message as unread (clears this user's read status for it)
+
+  markMessageUnread: async (messageId: number): Promise<void> => {
+    await apiClient.post(`/messages/messages/${messageId}/unread/`)
   },
 
   // Get total unread count

--- a/frontend/src/pages/MessagesPage.tsx
+++ b/frontend/src/pages/MessagesPage.tsx
@@ -558,6 +558,24 @@ export default function MessagesPage() {
     }
   }
 
+  // Shared cleanup after marking (part of) a conversation unread. We must leave
+  // the conversation so opening/listing it doesn't instantly re-mark it read
+  // (both via the server fetch and the auto-mark-read effect), reset the
+  // "already marked read this session" guard so re-opening marks it read again,
+  // and refresh the conversation list + unread badge.
+
+  const settleAfterMarkUnread = () => {
+    lastMarkedReadConversation.current = null
+
+    setSelectedConversation(null)
+
+    navigate("/beskeder", { replace: true })
+
+    queryClient.invalidateQueries({ queryKey: ["conversations"] })
+
+    queryClient.invalidateQueries({ queryKey: ["messages", "unread-count"] })
+  }
+
   const handleMarkUnread = async () => {
     const id = selectedConversation
 
@@ -566,23 +584,21 @@ export default function MessagesPage() {
     try {
       await messagingApi.markUnread(id)
 
-      // Reset the "already marked read this session" guard so that re-opening
-      // the conversation marks it read again.
-
-      lastMarkedReadConversation.current = null
-
-      // Leave the conversation so opening/listing it doesn't instantly re-mark
-      // it read (both via the server fetch and the auto-mark-read effect).
-
-      setSelectedConversation(null)
-
-      navigate("/beskeder", { replace: true })
-
-      queryClient.invalidateQueries({ queryKey: ["conversations"] })
-
-      queryClient.invalidateQueries({ queryKey: ["messages", "unread-count"] })
+      settleAfterMarkUnread()
     } catch (error) {
       showErrorNotification(error, "Kunne ikke markere samtalen som ulæst")
+    }
+  }
+
+  const handleMarkMessageUnread = async (messageId: number) => {
+    if (!selectedConversation) return
+
+    try {
+      await messagingApi.markMessageUnread(messageId)
+
+      settleAfterMarkUnread()
+    } catch (error) {
+      showErrorNotification(error, "Kunne ikke markere beskeden som ulæst")
     }
   }
 
@@ -800,6 +816,7 @@ export default function MessagesPage() {
                 }}
                 onLeave={handleLeaveConversation}
                 onMarkUnread={handleMarkUnread}
+                onMarkMessageUnread={handleMarkMessageUnread}
                 isMobile={isMobile ?? false}
                 onMessageUpdated={(messageId, content, editedAt) => {
                   queryClient.setQueryData<ConversationDetail>(
@@ -1006,6 +1023,8 @@ interface ChatAreaProps {
 
   onMarkUnread?: () => void
 
+  onMarkMessageUnread?: (messageId: number) => void
+
   onMessageUpdated?: (
     messageId: number,
 
@@ -1052,6 +1071,8 @@ interface MessageListProps {
 
   onUnsend?: (messageId: number) => void
 
+  onMarkMessageUnread?: (messageId: number) => void
+
   scrollViewportRef: RefObject<HTMLDivElement | null>
 }
 
@@ -1063,6 +1084,8 @@ const MessageList = memo(function MessageList({
   onEdit,
 
   onUnsend,
+
+  onMarkMessageUnread,
 
   scrollViewportRef,
 }: MessageListProps) {
@@ -1145,6 +1168,7 @@ const MessageList = memo(function MessageList({
                 showInlineTime={!isMobile}
                 onEdit={onEdit}
                 onUnsend={onUnsend}
+                onMarkMessageUnread={onMarkMessageUnread}
               />
             </Box>
           )
@@ -1166,6 +1190,8 @@ function ChatArea({
   onLeave,
 
   onMarkUnread,
+
+  onMarkMessageUnread,
 
   onMessageUpdated,
 
@@ -1602,6 +1628,7 @@ function ChatArea({
         isMobile={isMobile}
         onEdit={onMessageUpdated}
         onUnsend={onMessageDeleted}
+        onMarkMessageUnread={onMarkMessageUnread}
         scrollViewportRef={scrollRef}
       />
 
@@ -1740,6 +1767,8 @@ interface MessageBubbleProps {
   onEdit?: (messageId: number, content: string, editedAt: string) => void
 
   onUnsend?: (messageId: number) => void
+
+  onMarkMessageUnread?: (messageId: number) => void
 }
 
 function isImageFile(filename: string): boolean {
@@ -1758,6 +1787,8 @@ const MessageBubble = memo(function MessageBubble({
   onEdit,
 
   onUnsend,
+
+  onMarkMessageUnread,
 }: MessageBubbleProps) {
   const [carouselOpened, setCarouselOpened] = useState(false)
 
@@ -1989,6 +2020,14 @@ const MessageBubble = memo(function MessageBubble({
         <Menu.Item leftSection={<IconCopy size={14} />} onClick={handleCopy}>
           Kopiér
         </Menu.Item>
+        {!isOwn && (
+          <Menu.Item
+            leftSection={<IconMailOpened size={14} />}
+            onClick={() => onMarkMessageUnread?.(message.id)}
+          >
+            Markér som ulæst
+          </Menu.Item>
+        )}
         {isOwn && (
           <>
             <Menu.Divider />
@@ -2207,6 +2246,23 @@ const MessageBubble = memo(function MessageBubble({
               <Text size="sm">Kopiér</Text>
             </Group>
           </UnstyledButton>
+          {!isOwn && (
+            <UnstyledButton
+              px="xs"
+              py={6}
+              style={{ borderRadius: "var(--mantine-radius-sm)" }}
+              onClick={() => {
+                onMarkMessageUnread?.(message.id)
+
+                setReactionPickerOpened(false)
+              }}
+            >
+              <Group gap="xs">
+                <IconMailOpened size={14} color="var(--mantine-color-dimmed)" />
+                <Text size="sm">Markér som ulæst</Text>
+              </Group>
+            </UnstyledButton>
+          )}
           {isOwn && (
             <UnstyledButton
               px="xs"


### PR DESCRIPTION
Conversation-level "Markér som ulæst" now clears only the latest message from another participant (one unread reminder) instead of the whole conversation. Adds a per-message "Markér som ulæst" action below "Kopiér" in both the desktop bubble menu and the mobile action sheet (shown only on messages from others, since own messages are never tracked as unread).

Backend: new MarkMessageUnreadView (messages/<id>/unread/); conversation unread view marks only the latest non-own message (deterministic -created_at,-id ordering). New tests for latest-only and per-message.