### PR TITLE
Keep search query when reopening spotlight

### DIFF
--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -495,6 +495,10 @@ export function GlobalSearch({ onAction }: GlobalSearchProps) {
         }}
         query={query}
         onQueryChange={setQuery}
+        // Keep the last query when the spotlight closes so reopening it (incl.
+        // via Back after viewing a result) restores the previous search instead
+        // of an empty box. Mantine clears it by default.
+        clearQueryOnClose={false}
         transitionProps={{ duration: 0 }}
         shortcut={["mod + K"]}
         scrollable


### PR DESCRIPTION
Set clearQueryOnClose={false} so the last query is retained when the spotlight closes/reopens — including when reopening via Back after viewing a result. Mantine clears the query on close by default, which previously reopened the search with an empty box.