### PR TITLE
Put the full loan terms in the app

### DIFF
--- a/backend/apps/carsharing/constants.py
+++ b/backend/apps/carsharing/constants.py
@@ -36,19 +36,126 @@ TERMS_FILE = Path(__file__).resolve().parent / "vilkaar.md"
 # A date, so "which terms did they accept" is answerable by looking at a calendar.
 _VERSION_PATTERN = re.compile(r"^Version:\s*(\d{4}-\d{2}-\d{2})\s*$")
 _RATE_PLACEHOLDER = "{rate}"
+# A point that opens in bold carries a label for the case it covers ("**Anmeldes
+# skaden:** du betaler ..."). Section 5 is nine such cases, and losing the label
+# turns the one section where a misreading costs money into a wall of prose.
+_LEAD_PATTERN = re.compile(r"^\*\*(?P<lead>.+?)\*\*\s*(?P<rest>.*)$")
 
 
-def _parse_terms(text: str) -> tuple[str, str, tuple[str, ...]]:
-    """Pull the title, the date version and the bullets out of vilkaar.md.
+def _clean(text: str) -> str:
+    """Drop leftover bold markers, which would otherwise render as literal stars."""
+    return text.replace("**", "").strip()
 
-    Deliberately a hand-rolled reader rather than a Markdown library: the file is
-    a flat title-version-bullets document, the app renders the points as a plain
-    list, and adding a parser dependency for that would be the tail wagging the
-    dog. HTML comments carry the editing instructions and are skipped.
+
+class TermsBullet:
+    """One point, optionally introduced by a bold label."""
+
+    __slots__ = ("lead", "text")
+
+    def __init__(self, text: str, lead: str = "") -> None:
+        self.text = text
+        self.lead = lead
+
+    def filled(self, rate: str) -> "TermsBullet":
+        # str.replace, not str.format: the file is edited by hand, and format()
+        # would turn any stray brace into a crash at import.
+        return TermsBullet(self.text.replace(_RATE_PLACEHOLDER, rate), self.lead)
+
+    def as_dict(self) -> dict[str, str]:
+        return {"lead": self.lead, "text": self.text}
+
+    def as_line(self) -> str:
+        return f"{self.lead} {self.text}".strip() if self.lead else self.text
+
+
+class TermsSection:
+    """A numbered section: a heading, then paragraphs and points in file order."""
+
+    __slots__ = ("blocks", "heading", "open")
+
+    def __init__(self, heading: str) -> None:
+        self.heading = heading
+        # (kind, payload) where kind is "paragraph" (str) or "bullets" (list).
+        self.blocks: list[tuple[str, object]] = []
+        # Whether the last block is still taking wrapped lines. A blank line
+        # closes it, which is what separates two paragraphs of one section from
+        # one paragraph split across two lines for readability.
+        self.open = False
+
+    def _tail(self, kind: str) -> object | None:
+        if self.blocks and self.blocks[-1][0] == kind:
+            return self.blocks[-1][1]
+        return None
+
+    def add_bullet(self, bullet: TermsBullet) -> None:
+        existing = self._tail("bullets")
+        if isinstance(existing, list):
+            existing.append(bullet)
+        else:
+            self.blocks.append(("bullets", [bullet]))
+        self.open = True
+
+    def add_paragraph(self, text: str) -> None:
+        self.blocks.append(("paragraph", text))
+        self.open = True
+
+    def close(self) -> None:
+        self.open = False
+
+    def continue_last(self, text: str) -> bool:
+        """Append a wrapped line to whatever block is open. False if none is."""
+        if not self.open:
+            return False
+        bullets = self._tail("bullets")
+        if isinstance(bullets, list):
+            bullets[-1].text = f"{bullets[-1].text} {text}".strip()
+            return True
+        paragraph = self._tail("paragraph")
+        if isinstance(paragraph, str):
+            self.blocks[-1] = ("paragraph", f"{paragraph} {text}")
+            return True
+        return False
+
+    def filled(self, rate: str) -> "TermsSection":
+        copy = TermsSection(self.heading)
+        for kind, payload in self.blocks:
+            if kind == "bullets" and isinstance(payload, list):
+                copy.blocks.append(("bullets", [b.filled(rate) for b in payload]))
+            elif isinstance(payload, str):
+                copy.blocks.append(("paragraph", payload.replace(_RATE_PLACEHOLDER, rate)))
+        return copy
+
+    def as_dict(self) -> dict[str, object]:
+        blocks: list[dict[str, object]] = []
+        for kind, payload in self.blocks:
+            if kind == "bullets" and isinstance(payload, list):
+                blocks.append({"kind": "bullets", "items": [b.as_dict() for b in payload]})
+            elif isinstance(payload, str):
+                blocks.append({"kind": "paragraph", "text": payload})
+        return {"heading": self.heading, "blocks": blocks}
+
+    def as_lines(self) -> list[str]:
+        lines = [self.heading, ""]
+        for kind, payload in self.blocks:
+            if kind == "bullets" and isinstance(payload, list):
+                lines.extend(f"- {b.as_line()}" for b in payload)
+            elif isinstance(payload, str):
+                lines.append(payload)
+            lines.append("")
+        return lines
+
+
+def _parse_terms(text: str) -> tuple[str, str, tuple[TermsSection, ...]]:
+    """Pull the title, the date version and the sections out of vilkaar.md.
+
+    Deliberately a hand-rolled reader rather than a Markdown library: the file
+    uses one heading level, points and paragraphs, and nothing else. A Markdown
+    dependency would buy tables and images the terms must not contain anyway.
+    HTML comments carry the editing instructions and are skipped.
     """
     title = ""
     version = ""
-    bullets: list[str] = []
+    sections: list[TermsSection] = []
     in_comment = False
 
     for raw in text.splitlines():
@@ -62,6 +169,13 @@ def _parse_terms(text: str) -> tuple[str, str, tuple[str, ...]]:
             continue
 
         if not line:
+            # A blank line ends the current paragraph or list. Without this every
+            # section collapses into one run-on paragraph.
+            if sections:
+                sections[-1].close()
+            continue
+        if line.startswith("## "):
+            sections.append(TermsSection(line[3:].strip()))
             continue
         if line.startswith("# ") and not title:
             title = line[2:].strip()
@@ -70,17 +184,32 @@ def _parse_terms(text: str) -> tuple[str, str, tuple[str, ...]]:
         if match:
             version = match.group(1)
             continue
+        # Anything before the first heading is preamble, not a term.
+        if not sections:
+            continue
+
+        section = sections[-1]
         if line.startswith("- "):
-            bullets.append(line[2:].strip())
-        elif bullets:
-            # A bullet wrapped onto the next line, so the file can be read at a
-            # sane width without every point becoming one long line.
-            bullets[-1] = f"{bullets[-1]} {line}"
+            body = line[2:].strip()
+            lead_match = _LEAD_PATTERN.match(body)
+            if lead_match:
+                section.add_bullet(
+                    TermsBullet(
+                        _clean(lead_match.group("rest")),
+                        _clean(lead_match.group("lead")),
+                    )
+                )
+            else:
+                section.add_bullet(TermsBullet(_clean(body)))
+        # A point or paragraph wrapped onto the next line, so the file can be
+        # read at a sane width without every term becoming one long line.
+        elif not section.continue_last(_clean(line)):
+            section.add_paragraph(_clean(line))
 
-    return title, version, tuple(bullets)
+    return title, version, tuple(sections)
 
 
-def _load_terms() -> tuple[str, str, tuple[str, ...]]:
+def _load_terms() -> tuple[str, str, tuple[TermsSection, ...]]:
     """Read the terms at import, refusing to start on a broken file.
 
     Failing loudly is the point: a silently empty set of terms would mean
@@ -92,17 +221,19 @@ def _load_terms() -> tuple[str, str, tuple[str, ...]]:
     except OSError as exc:
         raise ImproperlyConfigured(f"Kunne ikke læse vilkårene i {TERMS_FILE}: {exc}") from exc
 
-    title, version, bullets = _parse_terms(text)
+    title, version, sections = _parse_terms(text)
     if not title:
         raise ImproperlyConfigured(f"{TERMS_FILE} mangler en overskrift ('# ...').")
     if not version:
         raise ImproperlyConfigured(f"{TERMS_FILE} mangler en 'Version: ÅÅÅÅ-MM-DD'-linje.")
-    if not bullets:
-        raise ImproperlyConfigured(f"{TERMS_FILE} indeholder ingen vilkår ('- ...').")
-    return title, version, bullets
+    if not sections:
+        raise ImproperlyConfigured(f"{TERMS_FILE} indeholder ingen afsnit ('## ...').")
+    if not any(section.blocks for section in sections):
+        raise ImproperlyConfigured(f"{TERMS_FILE} indeholder ingen vilkår under afsnittene.")
+    return title, version, sections
 
 
-LOAN_TERMS_TITLE, TERMS_VERSION, LOAN_TERMS_BULLETS = _load_terms()
+LOAN_TERMS_TITLE, TERMS_VERSION, LOAN_TERMS_SECTIONS = _load_terms()
 
 
 def _format_rate(rate: Decimal | None) -> str:
@@ -110,15 +241,16 @@ def _format_rate(rate: Decimal | None) -> str:
     return f"{effective:.2f}".replace(".", ",")
 
 
-def loan_terms_bullets(rate: Decimal | None = None) -> list[str]:
-    """The terms as separate points, with the applicable rate filled in."""
+def loan_terms_sections(rate: Decimal | None = None) -> list[dict[str, object]]:
+    """The terms as headed sections, with the applicable rate filled in."""
     formatted = _format_rate(rate)
-    # str.replace, not str.format: the file is edited by hand, and format() would
-    # turn any stray brace into a crash at import.
-    return [bullet.replace(_RATE_PLACEHOLDER, formatted) for bullet in LOAN_TERMS_BULLETS]
+    return [section.filled(formatted).as_dict() for section in LOAN_TERMS_SECTIONS]
 
 
 def loan_terms_text(rate: Decimal | None = None) -> str:
     """The terms as one plain-text block, for email and for the record."""
-    lines = "\n".join(f"- {bullet}" for bullet in loan_terms_bullets(rate))
-    return f"{LOAN_TERMS_TITLE}\n\n{lines}"
+    formatted = _format_rate(rate)
+    lines: list[str] = [LOAN_TERMS_TITLE, ""]
+    for section in LOAN_TERMS_SECTIONS:
+        lines.extend(section.filled(formatted).as_lines())
+    return "\n".join(lines).strip()

--- a/backend/apps/carsharing/tests.py
+++ b/backend/apps/carsharing/tests.py
@@ -169,18 +169,93 @@ def test_rate_snapshot_survives_later_rate_change(owner_house, borrower, borrowe
 # -- Terms: the file, and both parties' consent ------------------------------
 
 
+def _terms_lines(rate=None) -> list[str]:
+    """Every point and paragraph of the terms, flattened for assertions."""
+    from apps.carsharing.constants import loan_terms_sections
+
+    lines: list[str] = []
+    for section in loan_terms_sections(rate):
+        for block in section["blocks"]:
+            if block["kind"] == "bullets":
+                lines.extend(f"{item['lead']} {item['text']}".strip() for item in block["items"])
+            else:
+                lines.append(block["text"])
+    return lines
+
+
 def test_terms_come_from_the_markdown_file():
     """The file is the only source, so a parse failure must not pass silently."""
-    from apps.carsharing.constants import LOAN_TERMS_TITLE, TERMS_FILE, loan_terms_bullets
+    from apps.carsharing.constants import LOAN_TERMS_TITLE, TERMS_FILE, loan_terms_sections
 
     assert TERMS_FILE.exists()
     assert LOAN_TERMS_TITLE == "Vilkår for lån af bil i delebilparken"
-    bullets = loan_terms_bullets()
-    assert len(bullets) >= 5
+    sections = loan_terms_sections()
+    assert len(sections) >= 10
+    lines = _terms_lines()
     # Editing instructions live in an HTML comment and are not terms.
-    assert not any(bullet.startswith("<!--") or "-->" in bullet for bullet in bullets)
+    assert not any(line.startswith("<!--") or "-->" in line for line in lines)
     # Wrapped lines are joined rather than truncated at the wrap.
-    assert any("aflever den i samme stand" in bullet for bullet in bullets)
+    assert any("i samme stand som du fik den" in line for line in lines)
+
+
+def test_terms_keep_the_numbered_sections():
+    """The agreement is read by section number, so the headings must survive."""
+    from apps.carsharing.constants import loan_terms_sections
+
+    headings = [section["heading"] for section in loan_terms_sections()]
+    assert headings[0] == "Kort fortalt"
+    assert "5. Hvad du betaler, hvis der er sket skade" in headings
+    assert "11. Ændringer" in headings
+    # Every section carries something; an empty one means a parse slip.
+    assert all(section["blocks"] for section in loan_terms_sections())
+
+
+def test_a_blank_line_separates_two_paragraphs():
+    """A wrapped line continues a paragraph; a blank line starts a new one.
+
+    Without the distinction section 1 became one run-on block, which in a legal
+    text silently merges two separate provisions.
+    """
+    from apps.carsharing.constants import loan_terms_sections
+
+    section = next(s for s in loan_terms_sections() if s["heading"].startswith("1."))
+    paragraphs = [b["text"] for b in section["blocks"] if b["kind"] == "paragraph"]
+    assert len(paragraphs) == 2
+    assert paragraphs[0].startswith("Et lån er en privat aftale")
+    assert paragraphs[0].endswith("skader, tab eller udgifter.")
+    assert paragraphs[1].startswith("Når du sender en forespørgsel")
+
+
+def test_a_bold_opening_becomes_a_lead_label():
+    """Section 5 is nine cases, each introduced in bold. Losing that is unreadable."""
+    from apps.carsharing.constants import loan_terms_sections
+
+    section = next(s for s in loan_terms_sections() if s["heading"].startswith("5."))
+    bullets = [item for block in section["blocks"] for item in block.get("items", [])]
+    leads = [item["lead"] for item in bullets if item["lead"]]
+    assert "Anmeldes skaden:" in leads
+    assert "Loft:" in leads
+    # The lead is split off, not duplicated into the body.
+    anmeldes = next(item for item in bullets if item["lead"] == "Anmeldes skaden:")
+    assert anmeldes["text"].startswith("du betaler ejerens selvrisiko")
+
+
+def test_the_adopted_amounts_are_in_the_terms():
+    """The bracketed proposals were adopted; a stray bracket means a bad edit."""
+    lines = _terms_lines()
+    joined = " ".join(lines)
+    assert "3.000 kr." in joined
+    assert "8.000 kr." in joined
+    assert "24 timer" in joined
+    assert "[" not in joined and "]" not in joined
+
+
+def test_the_background_note_is_not_part_of_the_terms():
+    """The appendix reasons about insurance law; residents must not tick that."""
+    joined = " ".join(_terms_lines())
+    assert "erstatningsansvarsloven" not in joined
+    assert "bonusbeskyttelse" in joined.lower()  # the term itself does mention it
+    assert "telefonopringning" not in joined
 
 
 def test_terms_version_is_a_date():
@@ -188,11 +263,11 @@ def test_terms_version_is_a_date():
 
 
 def test_the_rate_placeholder_is_filled_in():
-    from apps.carsharing.constants import loan_terms_bullets, loan_terms_text
+    from apps.carsharing.constants import loan_terms_text
 
     assert "{rate}" not in loan_terms_text()
-    assert any("3,94" in bullet for bullet in loan_terms_bullets())
-    assert any("9,50" in bullet for bullet in loan_terms_bullets(Decimal("9.50")))
+    assert any("3,94" in line for line in _terms_lines())
+    assert any("9,50" in line for line in _terms_lines(Decimal("9.50")))
 
 
 def test_docs_symlink_is_the_same_file():
@@ -210,7 +285,16 @@ def test_a_malformed_terms_file_is_rejected(tmp_path):
 
     from apps.carsharing import constants
 
-    for text in ("", "# Kun en overskrift\n", "Version: 2026-08-04\n- Et vilkår\n"):
+    for text in (
+        "",
+        "# Kun en overskrift\n",
+        "Version: 2026-08-04\n- Et vilkår\n",
+        # Title and version, but the point sits before any section heading, so
+        # there are no terms to show.
+        "# En overskrift\n\nVersion: 2026-08-04\n\n- Et hjemløst vilkår\n",
+        # A heading with nothing under it is a slip, not an agreement.
+        "# En overskrift\n\nVersion: 2026-08-04\n\n## Tomt afsnit\n",
+    ):
         broken = tmp_path / "vilkaar.md"
         broken.write_text(text, encoding="utf-8")
         original = constants.TERMS_FILE
@@ -1358,15 +1442,27 @@ def test_terms_endpoint_serves_version_and_rate(authenticated_client):
 
 
 @pytest.mark.django_db
-def test_terms_are_plain_sentences_not_markdown(authenticated_client):
-    """Nothing in the app renders Markdown, so asterisks would show literally."""
+def test_terms_are_split_by_the_server_not_the_client(authenticated_client):
+    """The client renders no Markdown, so asterisks would show literally."""
     response = authenticated_client.get(reverse("carsharing-terms"))
     assert response.data["title"] == "Vilkår for lån af bil i delebilparken"
-    assert len(response.data["bullets"]) >= 5
-    for bullet in response.data["bullets"]:
-        assert "**" not in bullet
-        assert not bullet.startswith("- ")
-    assert "3,94 kr. pr. kørt km" in response.data["bullets"][-1]
+    sections = response.data["sections"]
+    assert len(sections) >= 10
+
+    for section in sections:
+        assert "#" not in section["heading"]
+        assert "**" not in section["heading"]
+        for block in section["blocks"]:
+            assert block["kind"] in ("paragraph", "bullets")
+            if block["kind"] == "bullets":
+                for item in block["items"]:
+                    assert "**" not in item["lead"]
+                    assert "**" not in item["text"]
+                    assert not item["text"].startswith("- ")
+            else:
+                assert "**" not in block["text"]
+
+    assert "3,94 kr. pr. kørt kilometer" in response.data["text"]
 
 
 # -- Replacing the whole schedule (the painting grid) ----------------------

--- a/backend/apps/carsharing/views.py
+++ b/backend/apps/carsharing/views.py
@@ -33,7 +33,7 @@ from .constants import (
     MAX_CANDIDATES_PER_LOAN,
     MAX_LOAN_DAYS,
     TERMS_VERSION,
-    loan_terms_bullets,
+    loan_terms_sections,
     loan_terms_text,
 )
 from .models import CarBlock, CarLoan, CarLoanCandidate
@@ -124,7 +124,7 @@ class TermsView(APIView):
             {
                 "version": TERMS_VERSION,
                 "title": LOAN_TERMS_TITLE,
-                "bullets": loan_terms_bullets(),
+                "sections": loan_terms_sections(),
                 "text": loan_terms_text(),
                 "default_rate_per_km": str(DEFAULT_RATE_PER_KM),
             }

--- a/backend/apps/carsharing/vilkaar.md
+++ b/backend/apps/carsharing/vilkaar.md
@@ -1,6 +1,6 @@
 # Vilkår for lån af bil i delebilparken
 
-Version: 2026-08-04
+Version: 2026-08-05
 
 <!--
 Dette er den eneste kilde til vilkårene. Appen læser filen direkte, så en
@@ -13,28 +13,152 @@ Regler for filen:
   ændres på en måde folk bør se igen. Hver bil gemmer hvilken version ejeren har
   accepteret, så en ny dato betyder at ejerne skal acceptere på ny, før deres
   biler igen kan lånes. Ret derfor ikke datoen for en kommatering.
-- Ét vilkår pr. punkt, indledt med "- ". Et punkt må gerne fortsætte på næste
-  linje.
+- Teksten er delt i afsnit. Et afsnit indledes med "## Overskrift" og indeholder
+  brødtekst, punkter ("- ") eller begge. Rækkefølgen bevares.
+- Et punkt eller et afsnit må gerne fortsætte på næste linje.
+- Fed skrift i starten af et punkt ("- **Sådan:** resten") vises som en
+  fremhævet indledning. Fed skrift midt i en sætning vises som almindelig tekst.
 - `{rate}` erstattes af den gældende km-takst (bilens egen, ellers
   fællesskabets standardsats). Andre pladsholdere findes ikke.
-- Ingen overskrifter udover den øverste: UI'et viser punkterne som en simpel
-  liste, ikke som formateret Markdown.
+- Baggrunden for teksten — hvorfor beløbene ser ud som de gør, og hvad der
+  stadig mangler i koden — står i `docs/bildeling-vilkaar-baggrund.md`. Den er
+  med vilje ikke en del af vilkårene og læses ikke af appen.
 
 Filen ligger i backend'en fordi den skal med i serverimaget.
 `docs/bildeling-vilkaar.md` er et symlink hertil, så der kun findes én tekst.
 -->
 
-- Du er ansvarlig for bilen, mens du har den. Kør forsigtigt og aflever den i
-  samme stand, som du fik den.
-- Sker der skade, eller virker noget ikke, giver du ejeren besked med det samme
-  — også småting. Udgangspunktet er, at låneren dækker selvrisikoen ved skader
-  opstået under lånet.
-- Almindeligt slid og mekanisk svigt, der ikke skyldes lånerens brug, er ejerens.
-- Bøder, parkerings- og broafgifter betaler du selv.
-- Du skal have gyldigt kørekort til bilen.
-- Der ligger en ladebrik i bilen, som virker de fleste steder. Har du haft
-  udgifter til strøm eller brændstof derudover, skriver du beløbet ind når du
-  afslutter lånet — det bliver trukket fra din betaling.
-- Prisen er den takst der står på bilen — {rate} kr. pr. kørt km, medmindre
-  ejeren har sat sin egen. Du oplyser de faktisk kørte kilometer, når du
-  afslutter lånet.
+## Kort fortalt
+
+Du er ansvarlig for bilen, mens du har den. Sker der noget, siger du det med det
+samme. Ved skade betaler du ejerens selvrisiko (står på bilens side) plus 3.000
+kr. for ejerens tab af skadefri år — dog samlet højst 8.000 kr. pr. lån. Bøder
+og afgifter er dine. Du betaler {rate} kr. pr. kørt km, minus hvad du selv har
+lagt ud til strøm.
+
+## 1. Hvem aftalen er mellem
+
+Et lån er en privat aftale mellem dig (låneren) og den husstand der ejer bilen
+(ejeren). Foreningen og appen formidler kontakten og regner beløbet ud, men er
+ikke part i aftalen og hæfter ikke for skader, tab eller udgifter.
+
+Når du sender en forespørgsel, accepterer du de vilkår der vises i appen på det
+tidspunkt. Den version gemmes på lånet, og det er den der gælder for netop det
+lån — også hvis vilkårene ændres bagefter.
+
+## 2. Hvem må køre bilen
+
+- Kun du, der har lånt bilen, må køre den. Skal andre køre, skal ejeren sige ja
+  først — skriv det i lånets tråd, så det står et sted.
+- Du skal have et kørekort til bilen, der er gyldigt i Danmark og hverken
+  betinget, inddraget eller frakendt, og du skal have haft det i mindst 2 år.
+- Er føreren under 25 år, har mange forsikringer en ekstra selvrisiko. Spørg
+  ejeren, inden du kører.
+- Du må ikke køre, hvis du er påvirket af alkohol, medicin eller andet, eller er
+  for træt til at køre sikkert.
+
+## 3. Sådan bruger du bilen
+
+- Kør forsigtigt, følg færdselsloven, og aflever bilen til aftalt tid, ryddet op
+  og i samme stand som du fik den — og med mindst den ladestand eller tankstand
+  du fik den med.
+- Overhold de vilkår ejeren oplyser om bilen og dens forsikring.
+- Bilen må ikke bruges til: erhvervsmæssig kørsel (herunder mad- og
+  pakkeudbringning og taxikørsel), motorsport, bane- eller terrænkørsel,
+  videreudlån, træk af mere end bilen er godkendt til, eller kørsel uden for
+  Danmark uden ejerens ja på forhånd. Flere af tingene kan koste dækningen på
+  ejerens forsikring, og så står du med hele regningen (punkt 5).
+- Rygning og dyr kun hvis det står i bilens beskrivelse.
+- Autostol til børn og andet du har brug for, sørger du selv for.
+- Dine egne ting i bilen er ikke forsikret.
+
+## 4. Sker der noget
+
+- Skriv eller ring til ejeren med det samme — også ved småting, og også hvis
+  noget bare ikke virker som det skal.
+- Ved uheld med andre implicerede: udfyld skadesanmeldelse på stedet, tag
+  billeder, og tilkald politiet ved personskade, uenighed, eller hvis en fører
+  ikke har gyldigt kørekort.
+- Tag billeder af bilen både når du henter den og når du afleverer den, og læg
+  dem i lånets tråd. Skader som ejeren gør dig opmærksom på senest 24 timer
+  efter aflevering, regnes som opstået under lånet, medmindre billederne viser
+  andet. Derefter er de ejerens.
+- Det er ejeren der beslutter, om en skade skal anmeldes til forsikringen. Det er
+  hendes police.
+
+## 5. Hvad du betaler, hvis der er sket skade
+
+- **Anmeldes skaden:** du betaler ejerens selvrisiko. Beløbet står på bilens side
+  i appen, så du kender det, inden du låner.
+- **Anmeldes skaden ikke:** du betaler de dokumenterede reparationsudgifter, dog
+  højst det selvrisikoen ville have været.
+- **Tab af skadefri år:** påvirker skaden ejerens præmie, betaler du 3.000 kr.
+  som fuld og endelig dækning af den højere præmie fremover. Der gøres ikke krav
+  op derudover. Beløbet betales ikke, hvis skaden ikke påvirker præmien — fx
+  fordi policen har bonusbeskyttelse, eller fordi det er en rude- eller
+  friskade, der efter ejerens police ikke koster skadefri år.
+- **Loft:** dit samlede ansvar for ét lån er højst 8.000 kr. Alt derover bærer
+  ejeren — det er den risiko, der følger med at melde sin bil i delebilparken.
+- **Loftet gælder ikke,** hvis du har handlet forsætligt eller groft uagtsomt
+  (fx spirituskørsel, grov hastighedsovertrædelse, kørsel uden gyldigt kørekort),
+  eller har brugt bilen i strid med punkt 2 eller 3. Så hæfter du for ejerens
+  fulde tab, herunder hvis forsikringen nedsætter eller nægter dækning eller
+  kræver beløbet tilbage fra dig.
+- **Uanset loftet betaler du** dokumenterede udgifter til fejltankning eller
+  forkert ladning, tabt eller ødelagt nøgle, ladebrik, ladekabel og tilbehør.
+- **Almindeligt slid og mekanisk svigt,** der ikke skyldes din brug, er ejerens —
+  også vejhjælp og reparation. Skyldes driftsstoppet din brug (kørt tom for
+  strøm, fejltankning, punktering mod en kantsten), betaler du.
+- **Ingen af jer** kan kræve erstatning af den anden for følgetab: aflyst tur,
+  taxa, mistet arbejdstid, værditab ud over ovenstående. Vi er naboer, ikke et
+  udlejningsfirma.
+
+## 6. Bøder og afgifter
+
+- Bøder, parkeringsafgifter, kontrolafgifter, bro- og færgeafgifter og
+  administrationsgebyrer for kørsel i din låneperiode betaler du — også når de
+  først dukker op måneder senere.
+- Du accepterer, at ejeren oplyser dit navn og din adresse som fører til politi,
+  parkeringsselskab eller myndighed, når der bliver spurgt.
+- Klip i kørekortet og andre personlige følger er dine.
+
+## 7. Betaling
+
+- Du dækker ejerens omkostninger med {rate} kr. pr. kørt kilometer. Satsen er
+  fastsat som deling af de faktiske omkostninger ved at holde bilen (afskrivning,
+  forsikring, service, dæk, afgift og strøm) og indeholder ingen fortjeneste. Der
+  er ikke tale om leje.
+- Kilometre opgøres efter bilens kilometertæller. Du oplyser standen ved start og
+  ved slut, når du afslutter lånet.
+- Der ligger en ladebrik i bilen, som virker de fleste steder, og strøm via
+  brikken er med i satsen. Har du haft udgifter til strøm eller brændstof
+  derudover, skriver du beløbet ind når du afslutter lånet — det trækkes fra din
+  betaling. Gem kvitteringen. Bliver beløbet negativt, skylder ejeren dig.
+- Beløbet betales til ejeren senest 7 dage efter lånet er afsluttet. Beløb
+  efter punkt 5 betales senest 14 dage efter ejeren har dokumenteret udgiften.
+- Afslutter du ikke lånet i appen, kan ejeren gøre det op selv ud fra
+  kilometertælleren.
+
+## 8. Aflysning, forsinkelse og tilbagekaldelse
+
+- Aflys i appen så snart du ved det.
+- Ejeren kan aflyse et lån, indtil det er startet. Efter start kan ejeren bede om
+  bilen tilbage ved et akut behov, og så afleverer du den, så snart det er sikkert
+  og rimeligt muligt.
+- Kan du ikke aflevere til tiden, skriver du til ejeren med det samme.
+
+## 9. Ejerens pligter
+
+En bil i delebilparken skal være indregistreret, forsikret, synet og i lovlig,
+køreklar stand med årstidsrigtige dæk. Ejeren oplyser kendte fejl og mangler,
+bilens selvrisiko og hvor nøgle og ladebrik ligger, inden lånet starter.
+
+## 10. Hvis I bliver uenige
+
+Tal først sammen. Kan I ikke blive enige, kan I bede bilgruppen om at mægle.
+Aftalen er underlagt dansk ret.
+
+## 11. Ændringer
+
+Vilkårene kan ændres af fællesmødet. Ændringer gælder for lån, der oprettes
+efter ændringen — for et igangværende lån gælder den version, der er gemt på det.

--- a/docs/bildeling-plan.md
+++ b/docs/bildeling-plan.md
@@ -312,11 +312,27 @@ godkendes på et fællesmøde uden at nogen skal kunne kode.
 sted. Grunden til at kilden ligger i backend'en og ikke i `docs/` er prosaisk:
 serverimaget bygges med `context: ./backend`, så `docs/` er ikke med i imaget.
 
-Filen har en overskrift, en `Version: ÅÅÅÅ-MM-DD`-linje og ét vilkår pr. `- `.
-`constants.py` læser og validerer den ved import og nægter at starte på en
+Filen har en overskrift, en `Version: ÅÅÅÅ-MM-DD`-linje og derefter nummererede
+afsnit indledt med `## `. Under et afsnit må der stå brødtekst, punkter (`- `)
+eller begge, og rækkefølgen bevares. En tom linje afslutter et afsnit eller en
+punktopstilling — uden den ville to selvstændige bestemmelser i samme afsnit
+smelte sammen til én. Fed skrift i starten af et punkt bliver en fremhævet
+indledning (`{"lead": "Loft:", "text": "dit samlede ansvar ..."}`), fordi punkt 5
+er ni tilfælde der hver især indledes sådan.
+
+`constants.py` læser og validerer filen ved import og nægter at starte på en
 ødelagt fil — tomme vilkår ville betyde at folk accepterede ingenting.
 `{rate}` erstattes af den gældende km-takst (`str.replace`, ikke `str.format`, så
 en tilfældig tuborgklamme i en håndredigeret fil ikke vælter importen).
+
+**Serveren deler teksten op, ikke klienten.** `/terms/` leverer færdige afsnit og
+punkter, så frontend aldrig skal fortolke Markdown — en `**` der slap igennem
+ville ellers stå som to stjerner midt i en juridisk tekst.
+
+Baggrunden for teksten — hvorfor beløbene er som de er, forholdet til
+erstatningsansvarslovens § 19, og hvad der stadig mangler i koden — står i
+`docs/bildeling-vilkaar-baggrund.md`. Den læses **ikke** af appen og er med
+vilje ikke en del af vilkårene.
 
 **Begge parter accepterer, og begge accepter gemmes:**
 
@@ -431,11 +447,21 @@ Stop efter 2 hvis brugen udebliver. Det er hele pointen med opdelingen.
 
 ## Åbne spørgsmål til jer
 
-1. **Vilkårsteksten skal godkendes af fællesskabet**, ikke af mig. Særligt to
-   punkter: et generelt "lånerens ansvar at bilen ikke går i stykker" kan ikke
-   dække almindeligt slid og mekanisk svigt uden lånerens skyld — derfor har
-   udkastet delt det i skade (låner) og slid/svigt (ejer). Og hvem bærer tabet af
-   skadefri år ved en anmeldt skade? Det står der ikke noget om endnu.
+1. **Vilkårsteksten skal godkendes af fællesskabet**, ikke af mig. Den fulde
+   tekst ligger nu i appen med de foreslåede beløb som gældende: 3.000 kr. for
+   ejerens tab af skadefri år, 8.000 kr. som loft over lånerens samlede ansvar,
+   24 timer til at gøre en skade gældende, 7 og 14 dages betalingsfrist, mindst
+   2 års kørekortanciennitet, Danmark som geografisk grænse, bilgruppen som
+   mægler. **Det er ikke det samme som at fællesmødet har sagt ja** — bekræft
+   beløbene og ret dem i `vilkaar.md`, hvis mødet lander et andet sted.
+   To ting mangler i koden, før punkt 5 og punkt 7 kan bære en reel uenighed:
+   - **`insurance_deductible` på `houses.Car`**, vist på bilkortet. Punkt 5
+     siger "Beløbet står på bilens side i appen", og det gør det ikke endnu. En
+     selvrisiko låneren ikke har set, kan låneren ikke binde sig til.
+   - **`start_km` / `end_km` frem for kun `actual_km`.** Punkt 7 siger "Du
+     oplyser standen ved start og ved slut", men afslutningsformularen beder kun
+     om de kørte kilometer. En tællerstand kan efterprøves; et husket tal kan
+     ikke.
 2. **Forsikring:** tjek at kr/km-afregningen ikke af nogens forsikringsselskab kan
    læses som erhvervsmæssig udlejning. Derfor bruges ordet "lån" konsekvent i UI'en
    og satsen omtales som deling af faktiske omkostninger — ikke leje.
@@ -444,8 +470,8 @@ Stop efter 2 hvis brugen udebliver. Det er hele pointen med opdelingen.
 4. **Hvad hvis låneren aldrig afslutter?** v1: ingenting — lånet står som aktivt og
    er synligt for ejeren, som kan rykke personligt. En Huey-påmindelse kan komme
    senere, hvis det viser sig at være et problem.
-5. **Dækker satsen ladning via brikken?** Udkastet antager ja, og at kun udgifter
-   *derudover* fratrækkes. Bekræft.
+5. **Dækker satsen ladning via brikken?** Vilkårenes punkt 7 siger nu ja, og at
+   kun udgifter *derudover* fratrækkes. Bekræft på mødet.
 
 ---
 

--- a/docs/bildeling-vilkaar-baggrund.md
+++ b/docs/bildeling-vilkaar-baggrund.md
@@ -1,0 +1,98 @@
+# Baggrund for vilkårene
+
+Ikke en del af vilkårene. Baggrund for den der senere skal vedligeholde teksten,
+og for den næste diskussion på et fællesmøde.
+
+Vilkårene selv står i [bildeling-vilkaar.md](bildeling-vilkaar.md) (et symlink
+til `backend/apps/carsharing/vilkaar.md`, som appen læser direkte). De beløb der
+tidligere stod i `[firkantede parenteser]` som forslag, står nu som gældende
+tekst: 3.000 kr. for tab af skadefri år, 8.000 kr. som loft, 24 timer til at
+gøre en skade gældende, 7 og 14 dages betalingsfrist, mindst 2 års
+kørekortanciennitet, Danmark som geografisk grænse, bilgruppen som mægler og
+fællesmødet som den der kan ændre vilkårene.
+
+## Om bonustabet
+
+Vi valgte et **fast beløb** frem for at gøre ejerens faktiske merpræmie op. Det
+er ikke fordi et fast beløb er mere retfærdigt, men fordi alternativet kræver at
+ejeren beder selskabet om en beregning og at nogen følger op i 3–5 år. Det sker
+ikke i praksis, og så ender tabet alligevel hos ejeren — bare med dårlig stemning
+oveni.
+
+Prisen for den forenkling er, at beløbet næsten altid er lidt forkert. Skønnet
+bag 3.000 kr.:
+
+- En anmeldt kaskoskade flytter typisk ejeren flere trin ned på skadefri-år-stigen,
+  og man vinder ét trin tilbage pr. skadefrit år. Merpræmien betales altså i
+  2–4 år, faldende.
+- Med en fuld forsikring i omegnen af 6.000–12.000 kr./år og en stigning på
+  15–30 % giver det groft 1.500–3.000 kr. det første år og et samlet tab i
+  størrelsesordenen 3.000–6.000 kr.
+- 1.500 kr. dækker altså cirka det første år. 3.000 kr. rammer den nedre halvdel
+  af det samlede tab og lader resten blive hos ejeren.
+
+Tallene varierer nok mellem selskaber til at de bør efterprøves. **Den præcise
+metode er én telefonopringning:** spørg selskabet "hvis jeg anmelder en
+kaskoskade på 20.000 kr., hvad betyder det for min præmie de næste fem år?".
+Gør det for to eller tre repræsentative biler i delebilparken og brug medianen.
+
+To ting, der ændrer billedet helt:
+
+- **Bonusbeskyttelse.** Flere selskaber sælger en tilvalgsdækning, hvor én skade
+  ikke koster skadefri år. Har en bil den, findes bonustabet ikke — derfor
+  sætningen i punkt 5 om at beløbet ikke betales, når præmien ikke påvirkes. Det
+  kan være billigere for delebilparken at betale for den dækning på de biler der
+  er med, end at diskutere bonustab bagefter.
+- **Opsigelse.** To skader inden for kort tid kan få selskabet til at opsige
+  policen, og så lander ejeren i en væsentligt dyrere tarif. Det tab ligger langt
+  over ethvert fast beløb, og loftet i punkt 5 lader det bevidst blive hos
+  ejeren. Det bør siges højt på fællesmødet, for det er den reelle risiko ved at
+  melde sin bil i delebilparken.
+
+Hvis der faktisk kommer skader, er næste skridt en **fælles skadespulje**:
+satsen forhøjes fx 0,15 kr./km til en kasse, der dækker selvrisiko og bonustab,
+og låneren betaler kun et lille fast beløb. Det kræver en kasse, en kasserer og
+en beslutning om hvad der sker når puljen er tom — derfor ikke nu.
+
+## Om ansvaret for skader
+
+Efter erstatningsansvarsloven § 19, stk. 1 bortfalder skadevolderens
+erstatningsansvar i det omfang skaden er dækket af en tingsforsikring.
+Konsekvensen er, at en låner der laver en bule ved almindelig uagtsomhed som
+udgangspunkt **ikke** hæfter — heller ikke for selvrisikoen — når kaskoen dækker.
+Undtagelsen er forsæt og grov uagtsomhed, stk. 2.
+
+Punkt 5 er derfor ikke en beskrivelse af retstilstanden, men en aftale, der skal
+indgås for at gælde. Det stiller tre krav:
+
+1. Låneren skal **aktivt acceptere** — afkrydsning med gemt tidsstempel, ikke
+   blot at teksten var på skærmen.
+2. Beløbene skal være **kendte før lånet**. Derfor skal selvrisikoen stå på
+   bilen, ikke i en police låneren ikke har set.
+3. Bonustabet skal nævnes eksplicit. Det er ikke dækket af forsikringen og falder
+   derfor ikke bort efter § 19 — men uden en aftale om det findes kravet ikke.
+
+Loftet er ikke kun venlighed: et åbent, potentielt stort ansvar kan lempes efter
+erstatningsansvarslovens § 24 og risikerer at blive tilsidesat efter aftalelovens
+§ 36. Et loft er både mere naboligt og mere holdbart end et ubegrænset krav.
+
+Ordet "leje" bruges bevidst ikke nogen steder, og satsen omtales som deling af
+faktiske omkostninger uden fortjeneste. Få det bekræftet af et
+forsikringsselskab, inden ordningen sættes i drift.
+
+Punkt 5 er det eneste sted, hvor et forkert ord koster penge. Overvej at få en
+jurist i foreningen — eller en times betalt rådgivning — til at læse netop det
+punkt.
+
+## Afhængigheder i koden
+
+Vilkårene forudsætter tre ting. Status pr. 2026-08-05:
+
+| Hvad | Hvorfor | Status |
+|---|---|---|
+| `insurance_deductible` på `houses.Car`, vist på bilkortet | Punkt 5 hænger på det — en ukendt selvrisiko kan låneren ikke binde sig til | **Mangler.** Punkt 5 siger "Beløbet står på bilens side i appen", og det gør det endnu ikke |
+| Afkrydsning med gemt tidsstempel | Forskellen mellem "teksten blev vist" og "låneren satte kryds" er hele bevisværdien | **På plads.** `CarLoan.terms_version` gemmer den accepterede version, og `created_at` er tidsstemplet. `Car.terms_accepted_version` + `terms_accepted_at` gør det samme for ejeren |
+| `start_km` / `end_km` frem for kun `actual_km` | Kilometertællerstand kan efterprøves; et husket tal kan ikke. `actual_km` bliver differencen | **Mangler.** Punkt 7 siger "Du oplyser standen ved start og ved slut", men appen beder kun om de kørte kilometer |
+
+De to manglende punkter er den vigtigste opgave, hvis vilkårene skal kunne stå
+for en reel uenighed. Se `bildeling-plan.md`.

--- a/frontend/src/pages/CarSharingPage.test.tsx
+++ b/frontend/src/pages/CarSharingPage.test.tsx
@@ -209,9 +209,31 @@ describe("CarSharingPage", () => {
     mockGetTerms.mockResolvedValue({
       version: "2026-08-01",
       title: "Vilkår for lån af bil i delebilparken",
-      bullets: [
-        "Du er ansvarlig for bilen, mens du har den.",
-        "Prisen er 3,94 kr. pr. kørt km.",
+      sections: [
+        {
+          heading: "Kort fortalt",
+          blocks: [
+            {
+              kind: "paragraph",
+              text: "Du er ansvarlig for bilen, mens du har den.",
+            },
+          ],
+        },
+        {
+          heading: "5. Hvad du betaler, hvis der er sket skade",
+          blocks: [
+            {
+              kind: "bullets",
+              items: [
+                {
+                  lead: "Loft:",
+                  text: "dit samlede ansvar er højst 8.000 kr.",
+                },
+                { lead: "", text: "Prisen er 3,94 kr. pr. kørt km." },
+              ],
+            },
+          ],
+        },
       ],
       text: "Vilkår for lån af bil i delebilparken\n\n- Prisen er 3,94 kr. pr. kørt km.",
       default_rate_per_km: "3.94",
@@ -271,8 +293,8 @@ describe("CarSharingPage", () => {
   it("folds the terms away but keeps the consent reachable", async () => {
     render(<CarSharingPage />)
 
-    // The heading and the checkbox are always there; on a phone the seven bullets
-    // would otherwise push the consent far below the fold.
+    // The heading and the checkbox are always there; the full agreement runs to a
+    // dozen sections and would otherwise push the consent far below the fold.
     await waitFor(() => {
       expect(
         screen.getByText("Vilkår for lån af bil i delebilparken"),
@@ -286,13 +308,23 @@ describe("CarSharingPage", () => {
     expect(
       screen.queryByText("Prisen er 3,94 kr. pr. kørt km."),
     ).not.toBeInTheDocument()
+    expect(screen.queryByText("Kort fortalt")).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole("button", { name: "Læs vilkårene" }))
 
     expect(
       await screen.findByText("Prisen er 3,94 kr. pr. kørt km."),
     ).toBeInTheDocument()
-    expect(screen.getAllByRole("listitem").length).toBeGreaterThanOrEqual(2)
+    // Section headings and paragraphs survive, not just the points.
+    expect(screen.getByText("Kort fortalt")).toBeInTheDocument()
+    expect(
+      screen.getByText("5. Hvad du betaler, hvis der er sket skade"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Du er ansvarlig for bilen, mens du har den."),
+    ).toBeInTheDocument()
+    // A bold lead renders as emphasis, not as literal asterisks.
+    expect(screen.getByText(/Loft:/)).toBeInTheDocument()
     expect(document.body.textContent).not.toContain("**")
   })
 

--- a/frontend/src/pages/carsharing/MyCarsTab.tsx
+++ b/frontend/src/pages/carsharing/MyCarsTab.tsx
@@ -246,6 +246,7 @@ function MyCarCard({ car }: MyCarCardProps) {
             {terms && !car.has_accepted_current_terms && (
               <TermsConsent
                 compact
+                collapsible
                 terms={terms}
                 intro="Dette er de vilkår, låneren accepterer, når din bil lånes. Som ejer bekræfter du, at din bil udlånes på dem."
                 label="Jeg har læst og accepterer vilkårene for at udlåne min bil"

--- a/frontend/src/pages/carsharing/shared.tsx
+++ b/frontend/src/pages/carsharing/shared.tsx
@@ -226,12 +226,38 @@ export function TermsConsent({
   // Collapsed by default when folding is on: the checkbox stays outside the fold
   // so consent is always one tap away, however long the terms get.
   const [open, setOpen] = useState(!collapsible)
-  const bullets = (
-    <List size="sm" spacing="xs">
-      {(terms.bullets ?? []).map((bullet) => (
-        <List.Item key={bullet}>{bullet}</List.Item>
+  const body = (
+    <Stack gap="md">
+      {(terms.sections ?? []).map((section) => (
+        <Stack gap="xs" key={section.heading}>
+          <Text size="sm" fw={600}>
+            {section.heading}
+          </Text>
+          {(section.blocks ?? []).map((block, index) =>
+            block.kind === "bullets" ? (
+              <List size="sm" spacing="xs" key={index}>
+                {(block.items ?? []).map((item) => (
+                  <List.Item key={item.lead + item.text}>
+                    {item.lead && (
+                      <Text
+                        component="span"
+                        fw={600}
+                        inherit
+                      >{`${item.lead} `}</Text>
+                    )}
+                    {item.text}
+                  </List.Item>
+                ))}
+              </List>
+            ) : (
+              <Text size="sm" key={index}>
+                {block.text}
+              </Text>
+            ),
+          )}
+        </Stack>
       ))}
-    </List>
+    </Stack>
   )
 
   return (
@@ -265,11 +291,11 @@ export function TermsConsent({
               {open ? "Skjul vilkårene" : "Læs vilkårene"}
             </Button>
             <Collapse expanded={open} keepMounted={false}>
-              {bullets}
+              {body}
             </Collapse>
           </>
         ) : (
-          bullets
+          body
         )}
         <Text size="xs" c="dimmed">
           Version {terms.version}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -287,13 +287,38 @@ export interface CarLoan {
   created_at: string
 }
 
+/** One point. `lead` is the bold label a point may open with, else empty. */
+export interface LoanTermsBullet {
+  lead: string
+
+  text: string
+}
+
+/**
+ * A paragraph or a run of points, in the order the terms file has them. The
+ * server does the splitting so the client never parses Markdown.
+ */
+export interface LoanTermsBlock {
+  kind: "paragraph" | "bullets"
+
+  text?: string
+
+  items?: LoanTermsBullet[]
+}
+
+export interface LoanTermsSection {
+  heading: string
+
+  blocks: LoanTermsBlock[]
+}
+
 export interface CarSharingTerms {
   version: string
 
   title: string
 
-  /** Plain sentences, rendered as a list. Deliberately not Markdown. */
-  bullets: string[]
+  /** The numbered sections of the agreement, already split by the server. */
+  sections: LoanTermsSection[]
 
   text: string
 


### PR DESCRIPTION
## Why

The real loan agreement was a **13 KB untracked file** in the working tree — in no commit and no
stash, so the only copy — while the app showed a distilled seven-bullet summary. This makes the full
document the single text.

The bracketed proposals are adopted as agreed values: **3.000 kr.** for the owner's lost no-claims
years, an **8.000 kr.** cap on the borrower's total liability, **24 hours** to raise a damage, **7**
and **14** day payment deadlines, **two years'** licence seniority, **Denmark**, and **bilgruppen**
as mediator.

⚠️ Adopting them in the file is not the same as the fællesmøde having approved them. If the meeting
lands elsewhere, edit `vilkaar.md` — that's the whole point of the terms living in Markdown.

## Why this wasn't a file swap

The old parser required a flat *title → `Version:` → bullets* file and explicitly forbade
sub-headings. Dropped in as-is the document would have raised `ImproperlyConfigured` and **stopped the
container**. And had I only patched the version line, the parser would have harvested the appendix's
bullets about insurance-premium economics and served them as terms for residents to tick.

So the terms are now section-aware:

- **Sections**: a `## ` heading, then paragraphs and points in file order.
- **A blank line closes the open block.** This is what separates two provisions of one section from
  one provision wrapped for readability. Without it, section 1 rendered as a single run-on paragraph
  — caught in the browser, fixed, and now covered by a test.
- **A point opening in bold keeps that label as a `lead`.** Section 5 is nine distinct cases each
  introduced that way, and it's the one section where a misreading costs money.
- **The server ships the split**, so the client still parses no Markdown — a stray `**` would
  otherwise render as two asterisks in a legal text.

`/api/carsharing/terms/` changes shape: `bullets: string[]` → `sections: [{heading, blocks}]`, where a
block is a paragraph or a run of points. Nothing else consumed `bullets`.

## The appendix

Moved to `docs/bildeling-vilkaar-baggrund.md` — the reasoning behind the amounts, the
erstatningsansvarslov § 19 analysis, and the "get a lawyer to read point 5" advice. The document
itself says this is not part of the terms, and the parser never reads it. I verified mechanically that
nothing was lost in the split: every line of the original is accounted for in one of the two files.

## Version bump

`TERMS_VERSION` → **2026-08-05**, so owners must re-accept before their cars can be borrowed again.
That's the mechanism working as designed — the terms they previously agreed to were materially
different. Production has no shared cars yet, so nobody is interrupted.

The owner's consent card is now **collapsible** too; twelve sections inside an already-long car-edit
form would otherwise bury the save button.

## Two promises the app doesn't yet keep

Recorded in `bildeling-plan.md` and the background note rather than left implicit:

- **`insurance_deductible` on `houses.Car`** — point 5 says *"Beløbet står på bilens side i appen"*,
  and it doesn't yet. A deductible the borrower hasn't seen can't be binding.
- **`start_km` / `end_km`** — point 7 says *"Du oplyser standen ved start og ved slut"*, but the
  settlement form only asks for kilometres driven. An odometer reading can be checked; a remembered
  number can't.

## Verification

- **890 backend / 493 frontend** tests; ty at its 22-diagnostic baseline; ruff, oxlint, oxfmt clean
- New tests: section headings survive, bold leads split correctly, blank lines separate paragraphs, no
  stray brackets, the appendix is *not* in the terms, and a heading with nothing under it is rejected
- Verified in a browser on a real production-sized database: 12 sections render, section 1 shows two
  paragraphs, bold leads render as emphasis, no `**` anywhere, consent reachable while collapsed
- Migrations: none. This is text and parsing only.

The one console error in dev is a WebSocket failure from the channel layer having no Redis locally —
it recurs on a fresh load and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
