### PR TITLE
Correct what kbintra.top actually runs on

### DIFF
--- a/frontend/src/utils/environment.ts
+++ b/frontend/src/utils/environment.ts
@@ -1,9 +1,11 @@
 /**
  * Which deployment the app is running in.
  *
- * Production is kb-intra.dk. kbintra.top is the test site, and it shares
- * production's database, so "test" here means *this browser is not on the real
- * domain* — it does not mean the data is throwaway.
+ * Production is kb-intra.dk. kbintra.top is the test site, and it runs on a
+ * *copy* of production's data: deploy-test.sh rsyncs prod's SQLite file and
+ * media into its own ./data on every test deploy, one-way, with prod as the
+ * source only. So writes on the test site never reach production, and anything
+ * created there is discarded by the next test deploy.
  *
  * Used to keep a feature that is still being trialled out of the way of the ~90
  * residents on the real site while the few of us testing it can reach it. Note


### PR DESCRIPTION
One comment fix, no behaviour change.

`environment.ts` claimed the test site shares production's database and that its data is
therefore not throwaway. `deploy-test.sh` shows otherwise: it rsyncs prod's SQLite file and
media into the test box's own `./data` on every test deploy, one-way with prod as the source
only, and the containers mount that `./data`. So writes on kbintra.top never reach
production, and test data is discarded by the next deploy.

Being wrong in that direction makes people test more timidly than they need to, which is the
opposite of what a test site is for.

Not urgent — it can ride along with whatever lands next; the deployed app is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)