### PR TITLE
ci: build images on main too, and fail fast when none exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,15 @@ jobs:
 
   # Build the production images on GitHub's runners (4 vCPU / 16 GB, free) and push
   # them to ghcr.io. The 4 GB prod box then only pulls — it never compiles. Runs only
-  # after all tests pass, and only on pushes to main (skipped on pull requests).
+  # after all tests pass, and only on pushes to develop or main (skipped on pull
+  # requests). Both branches build, so either one can be deployed; deploy.sh fails
+  # immediately on any other commit rather than waiting for an image CI never builds.
   build-push:
     name: Build & Push Images
     needs: [backend-lint, backend-test, frontend-lint, frontend-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -86,11 +86,15 @@ When enabled, media files are automatically synced to S3 via background tasks an
 
 ## Container Images (CI builds)
 
-App images are **built by CI, not on the server**. On every push to `main`, after
-tests pass, `.github/workflows/ci.yml` builds the backend and frontend images on
-GitHub's runners and pushes them to GitHub Container Registry (ghcr.io), tagged with
-both `latest` and the commit SHA. `deploy.sh` then only pulls — the 4 GB prod box
-never compiles, so deploys no longer starve the live app of RAM/CPU.
+App images are **built by CI, not on the server**. On every push to `develop` or
+`main`, after tests pass, `.github/workflows/ci.yml` builds the backend and frontend
+images on GitHub's runners and pushes them to GitHub Container Registry (ghcr.io),
+tagged with both `latest` and the commit SHA. `deploy.sh` then only pulls — the 4 GB
+prod box never compiles, so deploys no longer starve the live app of RAM/CPU.
+
+Only those two branch tips get images. Deploying any other commit (a feature branch,
+or a commit that was never the tip of a push) cannot work — `deploy.sh` detects this
+up front and fails immediately instead of waiting for an image that will never exist.
 
 Images:
 - `ghcr.io/tybirk/kbintra-backend` — used by the `backend`, `backend-ws`, and `huey` services
@@ -135,7 +139,7 @@ The script handles everything automatically:
 3. Pulls latest changes
 4. Backs up SQLite database locally (keeps last 10 in `./data/backups/`)
 5. Backs up SQLite database to S3 (if configured)
-6. **Pulls** the prebuilt images for the current commit from ghcr.io (waits up to 10 min if CI is still building), then restarts all containers (migrations run automatically on startup)
+6. **Pulls** the prebuilt images for the current commit from ghcr.io (waits up to 10 min if CI is still building this commit; fails right away if HEAD is not the tip of `develop` or `main`, since CI never builds an image for such a commit), then restarts all containers (migrations run automatically on startup)
 7. Prunes old Docker images
 8. Waits for backend health check
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -53,16 +53,30 @@ trap cleanup EXIT
 # never compiles. IMAGE_TAG = the exact commit we just checked out, so the running
 # code and the pulled image can never drift apart.
 export IMAGE_TAG=$(git rev-parse HEAD)
+
+# CI only builds images for the tips of develop and main (.github/workflows/ci.yml).
+# Waiting is worth it only while CI is plausibly building this very commit; for any
+# other commit no image will ever appear, so fail at once instead of stalling 10 min.
+pull_timeout=0
+if git ls-remote origin refs/heads/develop refs/heads/main 2>/dev/null | grep -q "^$IMAGE_TAG"; then
+    pull_timeout=600
+fi
+
 echo "Pulling images for $IMAGE_TAG from ghcr.io (old containers keep serving)..."
 
 # Normal case: you ran deploy.sh right after pushing and CI is still building/pushing
 # this commit's images. Retry the pull until they appear, up to 10 minutes.
-pull_timeout=600
 pull_elapsed=0
 until docker compose pull; do
     if [ "$pull_elapsed" -ge "$pull_timeout" ]; then
-        echo "ERROR: images for $IMAGE_TAG are not on ghcr.io after ${pull_timeout}s."
-        echo "Has CI finished building this commit? Check the Actions tab on GitHub."
+        if [ "$pull_timeout" -eq 0 ]; then
+            echo "ERROR: no image on ghcr.io for $IMAGE_TAG, and CI never builds one for it."
+            echo "HEAD ($(git rev-parse --abbrev-ref HEAD)) is not the tip of develop or main,"
+            echo "so no CI run ever built this commit. Check out develop (or main) and retry."
+        else
+            echo "ERROR: images for $IMAGE_TAG are not on ghcr.io after ${pull_timeout}s."
+            echo "Has CI finished building this commit? Check the Actions tab on GitHub."
+        fi
         echo "Is this host logged in? Run: docker login ghcr.io"
         exit 1
     fi


### PR DESCRIPTION
## Problem

CI built images only for the tip of `develop`, but `DEPLOY.md` and the `build-push` job's own comment both claimed `main`. Deploying prod with `main` checked out therefore retried the ghcr.io pull for 10 minutes and exited 1.

Not theoretical: `main`'s tip (`739a6c5`) ran CI on 2026-08-04 with **`Build & Push Images: skipped`**, so no image for that SHA was ever pushed. `develop` is 6 ahead / 0 behind `main`, so prod must be sitting on `develop` today — but nothing stops someone from deploying `main` and hitting the 10-minute stall.

## Changes

- **`.github/workflows/ci.yml`** — `build-push` now runs for `refs/heads/develop` **or** `refs/heads/main`, so either branch is deployable. `on.push.branches` already listed both. Stale comment corrected.
- **`deploy.sh`** — teaches the script the difference between "CI is still building this commit" and "CI will never build this commit". `pull_timeout` starts at `0` and only becomes `600` when `git ls-remote` reports HEAD as the tip of `develop` or `main`; the error path now names which case it is.
- **`DEPLOY.md`** — corrects the "on every push to `main`" claim and the step-6 bullet.

## Verification

- shellcheck: the four findings are all pre-existing lines (16, 38, 47, 55); the new block is clean. `sh -n deploy.sh` passes.
- Predicate exercised against three real SHAs: develop tip → wait 600s, main tip → wait 600s, a `feat/carpool` commit → fail fast.
- `ci.yml` parses; the folded `if` resolves to the intended single-line expression.

## What this PR's green check does *not* prove

`build-push` is skipped on pull requests, so the workflow condition only proves itself on a real push. **After merge, check that the next `develop` → `main` push shows *Build & Push Images: success* rather than *skipped*.**

Also note `deploy.sh` pulls before running its own new logic, so the first prod deploy after merge still executes the old script; the fail-fast starts from the second deploy.

## Out of scope

The branch model question is untouched: prod runs `develop`, `main` lags. This just means deploying either one works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)