### PR TITLE
Let a capitalised e-mail address log in

### DIFF
--- a/backend/apps/users/auth_backends.py
+++ b/backend/apps/users/auth_backends.py
@@ -1,0 +1,57 @@
+"""
+Authentication backends for KB Intra.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib.auth.backends import ModelBackend
+from django.http import HttpRequest
+
+from apps.users.models import User
+
+
+class CaseInsensitiveEmailBackend(ModelBackend):
+    """Authenticate on email ignoring case and surrounding whitespace.
+
+    Email addresses are case-insensitive in practice, and phone keyboards
+    routinely capitalise the first letter of one. The stock `ModelBackend`
+    looks the user up with an exact match, so `Anna@example.com` could not log
+    in while the forgot-password flow (`email__iexact`) kept working: the reset
+    mail arrived, the new password was set, and login still answered "wrong
+    e-mail or password" — with nothing to tell the member which of the two was
+    supposedly wrong.
+    """
+
+    def authenticate(
+        self,
+        request: HttpRequest | None,
+        username: str | None = None,
+        password: str | None = None,
+        **kwargs: Any,
+    ) -> User | None:
+        if username is None:
+            username = kwargs.get(User.USERNAME_FIELD)
+        if username is None or password is None:
+            return None
+
+        email = username.strip()
+        try:
+            user = User.objects.get(email__iexact=email)
+        except User.DoesNotExist:
+            # Hash once anyway so an unknown address takes the same time as a
+            # wrong password, keeping the two indistinguishable to a caller.
+            User().set_password(password)
+            return None
+        except User.MultipleObjectsReturned:
+            # Rows differing only by case predate this backend. Prefer the
+            # exact match, so those members keep the behaviour they had.
+            exact = User.objects.filter(email=email).first()
+            if exact is None:
+                return None
+            user = exact
+
+        if user.check_password(password) and self.user_can_authenticate(user):
+            return user
+        return None

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -356,6 +356,83 @@ class TestRegisterAPI:
         assert response.status_code == 400
 
 
+class TestLoginAPI:
+    """Tests for the token (login) API endpoint."""
+
+    def test_login_with_exact_email(self, api_client, user):
+        """Test logging in with the address exactly as stored."""
+        response = api_client.post(
+            "/api/auth/token/",
+            {"email": user.email, "password": "testpass123"},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert "access" in response.json()
+
+    def test_login_with_capitalised_email(self, api_client, user):
+        """Test that a capitalised address still logs in (phone keyboards)."""
+        response = api_client.post(
+            "/api/auth/token/",
+            {"email": "Test@Example.com", "password": "testpass123"},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert "access" in response.json()
+
+    def test_login_with_surrounding_whitespace(self, api_client, user):
+        """Test that a pasted address with stray whitespace still logs in."""
+        response = api_client.post(
+            "/api/auth/token/",
+            {"email": "  test@example.com  ", "password": "testpass123"},
+            format="json",
+        )
+        assert response.status_code == 200
+
+    def test_login_with_wrong_password_still_fails(self, api_client, user):
+        """Test that case-insensitivity does not weaken the password check."""
+        response = api_client.post(
+            "/api/auth/token/",
+            {"email": "TEST@EXAMPLE.COM", "password": "wrongpass"},
+            format="json",
+        )
+        assert response.status_code == 401
+
+    def test_login_with_unknown_email_fails(self, api_client, db):
+        """Test that an unregistered address is rejected."""
+        response = api_client.post(
+            "/api/auth/token/",
+            {"email": "nobody@example.com", "password": "testpass123"},
+            format="json",
+        )
+        assert response.status_code == 401
+
+    def test_inactive_user_cannot_log_in(self, api_client, user):
+        """Test that a deactivated member is still refused."""
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+        response = api_client.post(
+            "/api/auth/token/",
+            {"email": "Test@example.com", "password": "testpass123"},
+            format="json",
+        )
+        assert response.status_code == 401
+
+    def test_exact_match_wins_over_case_variant(self, api_client, db, user):
+        """Test that legacy rows differing only by case resolve to the exact one."""
+        User.objects.create_user(
+            email="TEST@example.com",
+            password="otherpass123",
+            first_name="Case",
+            last_name="Variant",
+        )
+        response = api_client.post(
+            "/api/auth/token/",
+            {"email": "TEST@example.com", "password": "otherpass123"},
+            format="json",
+        )
+        assert response.status_code == 200
+
+
 class TestChangePasswordAPI:
     """Tests for the Change Password API endpoint."""
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -153,6 +153,12 @@ DATABASES = {
 # Custom User Model
 AUTH_USER_MODEL = "users.User"
 
+# Email is the username field, so match it case-insensitively — a capitalised
+# address (phone keyboards do this) must still log in. Keep every backend here
+# in sync with `_AUTH_BACKEND` in config/urls.py: `auth.get_user()` silently
+# ignores a session whose recorded backend is not in this list.
+AUTHENTICATION_BACKENDS = ["apps.users.auth_backends.CaseInsensitiveEmailBackend"]
+
 # Password validation
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -17,7 +17,10 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from apps.backup.views import serve_media
 
-_AUTH_BACKEND = "django.contrib.auth.backends.ModelBackend"
+# Recorded in the session by `auth.login()` below. Must appear in
+# settings.AUTHENTICATION_BACKENDS, or `auth.get_user()` drops the session and
+# same-origin /media/* requests lose their credentials.
+_AUTH_BACKEND = "apps.users.auth_backends.CaseInsensitiveEmailBackend"
 
 
 class ThrottledTokenObtainPairView(TokenObtainPairView):

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -84,6 +84,10 @@ export default function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.currentTarget.value)}
               type="email"
+              autoComplete="email"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
             />
 
             <PasswordInput


### PR DESCRIPTION
Jeg kunne ikke logge ind. Jeg nulstillede min adgangskode mange gange — mailen kom, ny kode blev sat, men login sagde stadig "Forkert e-mail eller adgangskode".

Login slår e-mailen op med præcis match, mens glemt-adgangskode bruger `iexact`. Min telefon havde sat stort begyndelsesbogstav i adressen, så jeg kunne nulstille i en uendelighed uden at komme ind. Fejlbeskeden peger på adgangskoden, så man prøver bare igen.

Rettelsen gør login case-insensitivt, ligesom glemt-adgangskode. Præcis match vinder stadig, hvis to gamle brugere kun adskiller sig ved store og små bogstaver. Ukendte adresser kører hasheren én gang som før, og inaktive brugere bliver stadig afvist. `_AUTH_BACKEND` i `config/urls.py` skulle med, ellers ryger sessionen der giver adgang til `/media/*`, altså alle billeder i appen, uden fejl nogen steder. Loginfeltet får `autoCapitalize="none"`, så telefonen ikke sætter stort bogstav fra starten.

Testet: samme bruger og samme kode, hvor `demo@example.com` virker og `Demo@example.com` fejler før rettelsen og virker efter. Den nye test fejler uden rettelsen. 943 backend-tests og 537 frontend-tests kører rent, plus ruff, oxlint, oxfmt og tsgo. Prøvet gennem Vite-proxyen, altså samme vej som browseren.

Ikke testet: `autoCapitalize` på en rigtig telefon, og jeg har ikke kørt det på test- eller produktionsserveren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)